### PR TITLE
rename to "Asset Compute Worker SDK" and other readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Asset Compute SDK
-This shared library is used by all Asset Compute workers and takes care of common things like asset download & rendition upload.
+# Adobe Asset Compute Worker SDK
 
-- [Adobe Asset Compute SDK](#adobe-asset-compute-sdk)
+This library is required for all custom workers for the Adobe Asset Compute Service. It provides an easy to use framework and takes care of common things like asset & rendition access, validation and type checks, event notification, error handling and more.
+
   - [Installation](#installation)
   - [Overview](#overview)
   - [Examples](#examples)
@@ -26,10 +26,6 @@ This shared library is used by all Asset Compute workers and takes care of commo
     - [Contributing](#contributing)
     - [Licensing](#licensing)
 
-# Adobe Asset Compute SDK
-
-Adobe Asset Compute SDK library a shared library used by all Asset Compute workers and takes care of common functions like asset download & rendition upload.
-
 ## Installation
 
 ```bash
@@ -37,18 +33,18 @@ npm install @adobe/asset-compute-sdk
 ```
 
 ## Overview
-A high-level overview of Adobe Asset Compute worker SDK
+These are the high-level steps done by the Adobe Asset Compute Worker SDK:
 
 1. Setup
-- Initiates the New Relic metrics agent and Adobe IO Events handler (see [asset-compute-commons](https://github.com/adobe/asset-compute-commons) for more information)
-- Sets up the proper directories for local access to source and rendition
+   - Initiates the metrics agent and Adobe IO Events handler (see [asset-compute-commons](https://github.com/adobe/asset-compute-commons) for more information)
+   - Sets up the proper directories for local access to source and rendition
 2. Download source file from `url` in [`source`](#source) object
 3. Run `renditionCallback` function for each rendition ([worker](#renditioncallback-function-for-worker-required)) or for all the renditions at once ([batch worker](#renditioncallback-function-for-batchworker-required))
-- The rendition callback is where you put your worker logic. At the minimum, this function needs to convert the local source file into a local rendition file
+   - The rendition callback is where you put your worker logic. At the minimum, this function needs to convert the local source file into a local rendition file
 4. Upload renditions to `target` in [`rendition`](#rendition) object
 5. Notify the client via Adobe IO Events after each rendition
-- It sends a `rendition_created` or `rendition_failed` event depending on the outcome (see [Asset Compute API asynchronous events](https://git.corp.adobe.com/nui/nui/blob/master/doc/api.md#asynchronous-events) for more information)
-- If the worker is part of a chain of workers, it will only send successful rendition events after the last worker in the chain
+   - It sends a `rendition_created` or `rendition_failed` event depending on the outcome (see [Asset Compute API asynchronous events](https://git.corp.adobe.com/nui/nui/blob/master/doc/api.md#asynchronous-events) for more information)
+   - If the worker is part of a chain of workers, it will only send successful rendition events after the last worker in the chain
 ## Examples
 
 ### Simple javascript worker

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Adobe Asset Compute Worker SDK
 
+[![Version](https://img.shields.io/npm/v/@adobe/asset-compute-sdk.svg)](https://npmjs.org/package/@adobe/asset-compute-sdk)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Travis](https://travis-ci.com/adobe/asset-compute-sdk.svg?branch=master)](https://travis-ci.com/adobe/asset-compute-sdk)
+
 This library is required for all custom workers for the Adobe Asset Compute Service. It provides an easy to use framework and takes care of common things like asset & rendition access, validation and type checks, event notification, error handling and more.
 
   - [Installation](#installation)


### PR DESCRIPTION
"Asset Compute SDK" is a bit confusing as it does not include a way to call the service, for which we have the separate [asset-compute-client](https://github.com/adobe/asset-compute-client) library. And we need to include "Adobe" in the name. Hence I renamed it to "Adobe Asset Compute Worker SDK".

(The npm & repo name `asset-compute-sdk` is fine as is IMO).

Also improved text a bit & fixed some formatting. And removed mentioning of New Relic (shouldn't be in here IMO).

And added npm, license and travis badges.