### PR TITLE
Use canonical paths

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 'use strict';
 
 
-const path = require('path');
+const path = require('canonical-path');
 const fse = require('fs-extra');
 
 const WORK_DIRECTORY = "work";

--- a/lib/rendition.js
+++ b/lib/rendition.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 'use strict';
 
-const path = require('path');
+const path = require('canonical-path');
 const { RenditionMetadata } = require('./metadata');
 
 const RENDITION_BASENAME = 'rendition';

--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -16,7 +16,7 @@ const AssetComputeWorker = require('../worker');
 const { actionName } = require('../action');
 const errors = require('@adobe/asset-compute-commons');
 const fs = require('fs');
-const path = require('path');
+const path = require('canonical-path');
 const { spawn } = require('child_process');
 const stripAnsi = require('strip-ansi'); // escaping ansi content
 

--- a/lib/source.js
+++ b/lib/source.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 'use strict';
 
 const mime = require('mime-types');
-const path = require('path');
+const path = require('canonical-path');
 const validUrl = require('valid-url');
 const url = require('url');
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -18,7 +18,7 @@ const http = require('./storage/http');
 const datauri = require('./storage/datauri');
 const URL = require('url');
 const fs = require("fs-extra");
-const path = require('path');
+const path = require('canonical-path');
 
 const DATA_PROTOCOL = 'data:';
 

--- a/lib/storage/http.js
+++ b/lib/storage/http.js
@@ -16,7 +16,7 @@ const http = require('@adobe/httptransfer');
 const { AssetComputeLogUtils, GenericError, RenditionTooLarge } = require('@adobe/asset-compute-commons');
 const { actionName } = require('../action');
 const mime = require('mime-types');
-const path = require('path');
+const path = require('canonical-path');
 
 const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -471,9 +471,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -524,12 +524,13 @@
       }
     },
     "ambi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ambi/-/ambi-7.1.0.tgz",
-      "integrity": "sha512-OvWiv3gEy2ZNpHdDwoyJe7isWP2v9vZqFWEb2dzotHd8HMPTa5mIk6MLFjvVusbI7mhTBw++4xWipNhJAehW7Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-7.3.0.tgz",
+      "integrity": "sha512-RwJuvpa3uqyPozisbrvTB3QZfcYRmzcvxx7UIpa6RiORUNuSAORq5CFr0Mj5plFMFqFsdEXHwv2o4o+ubLQE/Q==",
       "dev": true,
       "requires": {
-        "typechecker": "^6.4.0"
+        "editions": "^2.3.0",
+        "typechecker": "^7.0.0"
       }
     },
     "ansi-colors": {
@@ -753,6 +754,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1108,6 +1114,14 @@
       "dev": true,
       "requires": {
         "typechecker": "^6.2.0"
+      },
+      "dependencies": {
+        "typechecker": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
+          "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
+          "dev": true
+        }
       }
     },
     "ecc-jsbn": {
@@ -1125,6 +1139,24 @@
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "editions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
+      "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
+      "dev": true,
+      "requires": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "emitter-listener": {
@@ -1150,15 +1182,22 @@
       }
     },
     "envfile": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/envfile/-/envfile-5.1.0.tgz",
-      "integrity": "sha512-6YsSCeyOMxCQp8YJPzK+xAn1V6jmNG7iejJNCAkcLN7AXtMFW9g5bz828o1k5RFA2M5hLlaX5E8VUlXSIyFKjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-5.2.0.tgz",
+      "integrity": "sha512-AvFbXqYw/zZCQLSt3KisBTf42nNAgZ9mkewvTfoPtYuBeIld7UMmNvVQewVu4c0w93STUAfyZZf8DS4jD7JTag==",
       "dev": true,
       "requires": {
-        "ambi": "^7.1.0",
+        "ambi": "^7.3.0",
         "eachr": "^4.5.0",
-        "typechecker": "^6.4.0"
+        "editions": "^2.3.0",
+        "typechecker": "^7.0.0"
       }
+    },
+    "errlop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1451,9 +1490,9 @@
       "dev": true
     },
     "fetch-mock": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.5.0.tgz",
-      "integrity": "sha512-x5t6+6owOr2x8WdloBpuKy7bRZ+JRjRJjjZSsEbBVNfUI8JzJfRw5TtdOOd+OyWXxqQtMjMLdRWh35ZLhRlv3g==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.7.0.tgz",
+      "integrity": "sha512-f7/qRIllBXrVyJ/AWutduAbCo/DuRkStMWweprfFjr+DJhK92aNNFfdVPNxvn4kime/XhGqZZKD/zT8u/ouNvw==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -2153,15 +2192,12 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
-      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
-        "@babel/parser": "^7.7.5",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
@@ -3074,9 +3110,9 @@
       }
     },
     "openwhisk": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.1.tgz",
-      "integrity": "sha512-cinF78O4TVxEOhlLW1DyuPxzNLiqY3aYj7gQ9QmDAFjln66kbiMxdWmsaELKkyVwpjn8tWLhikPylBygAq+b6w==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.21.2.tgz",
+      "integrity": "sha512-Fxx1fupwZaKxbzpN/pCd0PLItRAjS9PXJCnm+JFPY7592koQlYTQo3t7DpBVYTiqIUx9Z1kKdpla3JyLaZSXIA==",
       "requires": {
         "needle": "^2.4.0"
       }
@@ -3500,9 +3536,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -3975,9 +4011,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.12.0.tgz",
+      "integrity": "sha512-5rxCQkP0kytf4H1T4xz1imjxaUUPMvc5aWp0rJ/VMIN7ClRiH1FwFvBt8wOeMasp/epeUnmSW6CixSIePtiLqA==",
       "dev": true
     },
     "tunnel-agent": {
@@ -4015,9 +4051,9 @@
       "dev": true
     },
     "typechecker": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
-      "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-7.0.0.tgz",
+      "integrity": "sha512-ZCrFdtqmB2EaHUOkfdVwCVr43mECsPdzTgEwlWI+GCmPBW2gjVHU2HgXI/ci4nLGbfAIUIWDKSYgseUTh4RBqw==",
       "dev": true
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.2.0",
-    "envfile": "^5.1.0",
+    "envfile": "^5.2.0",
     "expect.js": "^0.3.1",
-    "fetch-mock": "^9.5.0",
+    "fetch-mock": "^9.7.0",
     "lockfile-lint": "^4.2.2",
     "lodash": "^4.17.15",
     "mocha": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "url": "adobe/asset-compute-sdk"
   },
   "dependencies": {
-    "@adobe/httptransfer": "^1.0.1",
-    "@adobe/node-fetch-retry": "^1.0.1",
     "@adobe/asset-compute-commons": "^1.0.1",
-    "@adobe/metrics-sampler": "^1.0.0",
-    "ajv": "6.12.2",
     "@adobe/cgroup-metrics": "^3.0.0",
+    "@adobe/httptransfer": "^1.0.1",
+    "@adobe/metrics-sampler": "^1.0.0",
+    "@adobe/node-fetch-retry": "^1.0.1",
+    "ajv": "6.12.2",
+    "canonical-path": "^1.0.0",
     "clone": "^2.1.2",
     "data-uri-to-buffer": "^3.0.0",
     "deprecation": "^2.3.1",

--- a/test/logfile.setup.js
+++ b/test/logfile.setup.js
@@ -28,7 +28,7 @@ const TEST_LOG_FILE = process.env.MOCHA_TEST_LOG_FILE || "build/mocha.test.log";
 
 const clone = require('clone');
 const util = require('util');
-const path = require('path');
+const path = require('canonical-path');
 const fsExtra = require('fs-extra');
 
 // ---------------------------------------------------------------------

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -19,7 +19,7 @@ const fse = require('fs-extra');
 const assert = require('assert');
 const sinon = require('sinon');
 
-const path = require('path');
+const path = require('canonical-path');
 const {createDirectories, cleanupDirectories} = require('../lib/prepare');
 
 describe('prepare.js', () => {

--- a/test/shellscript.test.js
+++ b/test/shellscript.test.js
@@ -22,7 +22,7 @@ const testUtil = require('./testutil');
 const assert = require('assert');
 const mockFs = require('mock-fs');
 const fs = require('fs');
-const path = require("path");
+const path = require('canonical-path');
 const envfile = require("envfile");
 const { MetricsTestHelper } = require("@adobe/asset-compute-commons");
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -20,7 +20,7 @@ const mockFs = require('mock-fs');
 const nock = require('nock');
 const assert = require('assert');
 const fs = require('fs-extra');
-const path = require('path');
+const path = require('canonical-path');
 const { GenericError } = require('@adobe/asset-compute-commons');
 
 describe('storage.js', () => {


### PR DESCRIPTION
## Description

Use canonical paths to be operating system independent.

Fixes some failing tests on Windows.

## Types of changes

Use canonical paths in tests and everywhere to be operating system independent. Path will always returns paths separated by `/`, rather than operating system dependent strings. This prevents string comparision issues for paths in our unit tests.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
