### PR TITLE
update cgroup-metrics to get rid of codecov as production dependency, fix codecov in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Adobe Asset Compute Worker SDK
-
 [![Version](https://img.shields.io/npm/v/@adobe/asset-compute-sdk.svg)](https://npmjs.org/package/@adobe/asset-compute-sdk)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![codecov](https://codecov.io/gh/adobe/asset-compute-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/adobe/asset-compute-sdk)
 [![Travis](https://travis-ci.com/adobe/asset-compute-sdk.svg?branch=master)](https://travis-ci.com/adobe/asset-compute-sdk)
+
+# Adobe Asset Compute Worker SDK
 
 This library is required for all custom workers for the Adobe Asset Compute Service. It provides an easy to use framework and takes care of common things like asset & rendition access, validation and type checks, event notification, error handling and more.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,11 +43,10 @@
       }
     },
     "@adobe/cgroup-metrics": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/cgroup-metrics/-/cgroup-metrics-3.0.0.tgz",
-      "integrity": "sha512-JC4yafqEMCw0L3i7WpClawIu62GSHrWvnKFDjmrXTyVvbd2zE75bpRvM0QoPPJk1etnOhH3zAdKxUk+LU7IL1g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@adobe/cgroup-metrics/-/cgroup-metrics-3.0.1.tgz",
+      "integrity": "sha512-nnjOWwUo0ONtwEhhT5lZntJoBVPs+r6DtC+3DWPuJjww2lJ827O2oZfNoyrmV7Ya12GfYEUbe/QjIaXsKwPZag==",
       "requires": {
-        "codecov": "^3.6.5",
         "flat": "^5.0.0"
       }
     },
@@ -402,7 +401,8 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -475,6 +475,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
       "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -588,6 +589,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -595,7 +597,8 @@
     "argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas="
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -856,6 +859,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
       "integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
+      "dev": true,
       "requires": {
         "argv": "0.0.2",
         "ignore-walk": "3.0.3",
@@ -1439,7 +1443,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.3.1",
@@ -1936,6 +1941,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
       "requires": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -1964,6 +1970,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
       "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "dev": true,
       "requires": {
         "agent-base": "5",
         "debug": "4"
@@ -1972,7 +1979,8 @@
         "agent-base": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+          "dev": true
         }
       }
     },
@@ -1999,6 +2007,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -2441,6 +2450,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3968,7 +3978,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -3995,6 +4006,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "dev": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -4079,7 +4091,8 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -4164,6 +4177,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
       "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
+      "dev": true,
       "requires": {
         "http-proxy-agent": "^4.0.0",
         "https-proxy-agent": "^4.0.0",
@@ -4359,7 +4373,8 @@
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8="
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -856,9 +856,9 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "codecov": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
-      "integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.2.tgz",
+      "integrity": "sha512-fmCjAkTese29DUX3GMIi4EaKGflHa4K51EoMc29g8fBHawdk/+KEq5CWOeXLdd9+AT7o1wO4DIpp/Z1KCqCz1g==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.3.0",
-    "codecov": "^3.7.0",
+    "codecov": "^3.7.1",
     "envfile": "^5.2.0",
     "expect.js": "^0.3.1",
     "fetch-mock": "^9.10.3",
@@ -62,6 +62,7 @@
     "test": "nyc mocha test --file test/logfile.setup.js --recursive --exit",
     "posttest": "eslint ./ && license-checker --summary && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
     "beautify": "eslint ./ --fix",
-    "unit-test": "nyc --reporter=html --reporter=text mocha test --recursive --exit -- -v"
+    "unit-test": "nyc --reporter=html --reporter=text mocha test --recursive --exit -- -v",
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "adobe"
   ],
   "scripts": {
-    "test": "nyc mocha test --file test/logfile.setup.js --recursive --exit",
+    "test": "nyc -r=text -r=lcov mocha test --file test/logfile.setup.js --recursive --exit",
     "posttest": "eslint ./ && license-checker --summary && ./node_modules/lockfile-lint/bin/lockfile-lint.js --path package-lock.json —type npm --allowed-hosts npm artifactory.corp.adobe.com --allowed-schemes \"https:\" \"file:\" --empty-hostname true",
     "beautify": "eslint ./ --fix",
     "unit-test": "nyc --reporter=html --reporter=text mocha test --recursive --exit -- -v",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@adobe/asset-compute-commons": "^1.1.1",
-    "@adobe/cgroup-metrics": "^3.0.0",
+    "@adobe/cgroup-metrics": "^3.0.1",
     "@adobe/httptransfer": "^1.0.1",
     "@adobe/metrics-sampler": "^1.0.0",
     "@adobe/node-fetch-retry": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.3.0",
-    "codecov": "^3.7.1",
+    "codecov": "^3.7.2",
     "envfile": "^5.2.0",
     "expect.js": "^0.3.1",
     "fetch-mock": "^9.10.3",


### PR DESCRIPTION
## Description

- bring in https://github.com/adobe/node-cgroup-metrics/pull/22
- make codecov work

Only merge after #26 to get automatic release in.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

