### PR TITLE
npm audit fix for dot-prop vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,13 +1320,13 @@
       "dev": true
     },
     "compare-func": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-      "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
-        "dot-prop": "^3.0.0"
+        "dot-prop": "^5.1.0"
       }
     },
     "concat-map": {
@@ -1371,13 +1371,40 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "conventional-changelog-angular": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-      "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+      "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "q": "^1.5.1"
+      },
+      "dependencies": {
+        "compare-func": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^5.1.0"
+          }
+        },
+        "dot-prop": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "dev": true,
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+          "dev": true
+        }
       }
     },
     "conventional-changelog-eslint": {
@@ -1390,12 +1417,12 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-      "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+      "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
       "dev": true,
       "requires": {
-        "compare-func": "^1.3.1",
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.6",
         "dateformat": "^3.0.0",
         "handlebars": "^4.7.6",
@@ -1669,12 +1696,12 @@
       }
     },
     "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "^2.0.0"
       }
     },
     "duplexer2": {
@@ -3025,9 +3052,9 @@
       "dev": true
     },
     "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
     "is-plain-obj": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@adobe/eslint-config-asset-compute": "^1.3.0",
-    "@semantic-release/git": "9.0.0",
+    "@semantic-release/git": "^9.0.0",
     "codecov": "^3.7.2",
-    "conventional-changelog-eslint": "3.0.8",
+    "conventional-changelog-eslint": "^3.0.8",
     "envfile": "^5.2.0",
     "expect.js": "^0.3.1",
     "fetch-mock": "^9.10.3",
@@ -51,7 +51,7 @@
     "read-chunk": "^3.2.0",
     "rewire": "^5.0.0",
     "rimraf": "^3.0.2",
-    "semantic-release": "17.0.7",
+    "semantic-release": "^17.0.7",
     "sinon": "^9.0.2"
   },
   "keywords": [


### PR DESCRIPTION
Fixes https://github.com/adobe/asset-compute-sdk/network/alert/package-lock.json/dot-prop/open

Still missing: semantic-release update, which is blocked because it is `--save-exact` (I think):
```
> npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ dot-prop                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.1.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ semantic-release [dev]                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ semantic-release > @semantic-release/npm > npm > libnpx >    │
│               │ update-notifier > configstore > dot-prop                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1213                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ dot-prop                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.1.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ semantic-release [dev]                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ semantic-release > @semantic-release/npm > npm >             │
│               │ update-notifier > configstore > dot-prop                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1213                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 2 high severity vulnerabilities in 1221 scanned packages
  2 vulnerabilities require manual review. See the full report for details.

```