### PR TITLE
NUI-709 NUI developers should not use rendition.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Object containing the following attributes:
 | `name` | `string` | filename of the rendition to create |
 | `path` | `string` | Absolute path to store rendition locally (must put rendition here in order to be uploaded to cloud storage) |
 | `index` | `number` | number used to identify a rendition |
-| `target` | `string` or `object` | URL to which the generated rendition should be uploaded or multipart pre-signed URL upload information for the generated rendition |
+| `target` | `string` or `object` | A single URL string to which the generated rendition should be uploaded or an object array containing many multipart pre-signed URLs for the generated rendition </br> While developing, `rendition.target` should not be used |
 
 ##### **`params`**
 original parameters passed into the worker (see full [Asset Compute prcoessing API Doc](https://git.corp.adobe.com/nui/nui/blob/master/doc/api.md#asset-processing))
@@ -163,7 +163,7 @@ The parameters for the rendition callback function are: `source`, `renditions`, 
 ##### **`source`**
 Source is the exact same as for `renditionCallback` in `worker`
 ##### **`renditions`**
-Renditions are an array of renditions. Each rendition has the same structure as for `renditionCallback` in `worker`
+Renditions is an array of `rendition` objects. Each `rendition` object has the same structure as for `renditionCallback` in `worker`
 ##### **`outdir`**
 directory to put renditions produced in batch workers
 ##### **`params`**

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ These are the high-level steps done by the Adobe Asset Compute Worker SDK:
 2. Download source file from `url` in [`source`](#source) object
 3. Run `renditionCallback` function for each rendition ([worker](#renditioncallback-function-for-worker-required)) or for all the renditions at once ([batch worker](#renditioncallback-function-for-batchworker-required))
    - The rendition callback is where you put your worker logic. At the minimum, this function needs to convert the local source file into a local rendition file
-4. Upload renditions to `target` in [`rendition`](#rendition) object
-5. Notify the client via Adobe IO Events after each rendition
+4. Notify the client via Adobe IO Events after each rendition
    - It sends a `rendition_created` or `rendition_failed` event depending on the outcome (see [Asset Compute API asynchronous events](https://git.corp.adobe.com/nui/nui/blob/master/doc/api.md#asynchronous-events) for more information)
    - If the worker is part of a chain of workers, it will only send successful rendition events after the last worker in the chain
 ## Examples
@@ -127,7 +126,6 @@ Object containing the following attributes:
 | `name` | `string` | filename of the rendition to create |
 | `path` | `string` | Absolute path to store rendition locally (must put rendition here in order to be uploaded to cloud storage) |
 | `index` | `number` | number used to identify a rendition |
-| `target` | `string` or `object` | A single URL string to which the generated rendition should be uploaded or an object array containing many multipart pre-signed URLs for the generated rendition </br> While developing, `rendition.target` should not be used |
 
 ##### **`params`**
 original parameters passed into the worker (see full [Asset Compute prcoessing API Doc](https://git.corp.adobe.com/nui/nui/blob/master/doc/api.md#asset-processing))


### PR DESCRIPTION
## Description

Updated readme to describe renditions a little better and to mention developers not to use `rendition.target`
[NUI-709 NUI developers should not use rendition.target](developers should not use rendition.target)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
