### PR TITLE
add option.json for shellscript opt-in post processing

### DIFF
--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -79,9 +79,14 @@ class ShellScriptWorker {
             }
 
             if (await fs.pathExists(optionsFile)) {
-                const options = await fs.readJSON(optionsFile);
-                if (options.postProcess === true) {
-                    rendition.postProcess = true;
+                try {
+                    const options = await fs.readJSON(optionsFile);
+                    if (options.postProcess === true) {
+                        rendition.postProcess = true;
+                    }
+                // eslint-disable-next-line no-unused-vars
+                } catch (e) {
+                    // ignore error if options file is not properly formatted
                 }
             }
         } catch (err) {

--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -50,11 +50,8 @@ class ShellScriptWorker {
 
         const preparedFiles = await prepareMetadata(rendition.directory);
 
-        // rendition options file for optiosn like postProcess
-        const optionsFile = path.resolve(rendition.directory, 'options.json');
-
         // inherit environment variables
-        const env = setVariables(rendition, source, preparedFiles.errorFile, preparedFiles.typeFile, optionsFile);
+        const env = setVariables(rendition, source, preparedFiles);
 
         try {
             // use of spawn() with separate arguments prevents shell/command injection
@@ -63,7 +60,7 @@ class ShellScriptWorker {
             // process metadata, if any 
             if(await fs.pathExists(preparedFiles.typeFile)){ // use the path containing the file with mime information
                 console.log('Reading content type information from worker generated file');
-                
+
                 let mimeInfoContent = await fs.readFile(preparedFiles.typeFile);
                 mimeInfoContent = mimeInfoContent.toString();
                 mimeInfoContent = mimeInfoContent.trim();
@@ -78,9 +75,9 @@ class ShellScriptWorker {
                 console.log('No content type information file found');
             }
 
-            if (await fs.pathExists(optionsFile)) {
+            if (await fs.pathExists(preparedFiles.optionsFile)) {
                 try {
-                    const options = await fs.readJSON(optionsFile);
+                    const options = await fs.readJSON(preparedFiles.optionsFile);
                     if (options.postProcess === true || options.postProcess === "true") {
                         rendition.postProcess = true;
                     }
@@ -104,9 +101,13 @@ async function prepareMetadata(directory) {
     // Folder structure has activationid as root, so concurrent executions should not collide
     const typeFile = path.resolve(errDir, "type.txt");
 
+    // rendition options file for optiosn like postProcess
+    const optionsFile = path.resolve(directory, 'options.json');
+
     return {
         errorFile: errFile,
-        typeFile: typeFile
+        typeFile: typeFile,
+        optionsFile: optionsFile
     };
 }
 
@@ -155,15 +156,15 @@ function newScriptError(err, errorFile) {
     return resultErr;
 }
 
-function setVariables(rendition, source, errorFile, typeFile, optionsFile){
+function setVariables(rendition, source, preparedFiles){
     // inherit environment variables
     const env = Object.create(process.env || {});
 
     env.source = env.file = stripAnsi(source.path); // escape because user provided
     env.rendition = stripAnsi(rendition.path);
-    env.errorfile = errorFile;
-    env.typefile = typeFile;
-    env.optionsfile = optionsFile;
+    env.errorfile = preparedFiles.errorFile;
+    env.typefile = preparedFiles.typeFile;
+    env.optionsfile = preparedFiles.optionsFile;
 
     const instructions = rendition.instructions;
 

--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -50,8 +50,11 @@ class ShellScriptWorker {
 
         const preparedFiles = await prepareMetadata(rendition.directory);
 
+        // rendition options file for optiosn like postProcess
+        const optionsFile = path.resolve(rendition.directory, 'options.json');
+
         // inherit environment variables
-        const env = setVariables(rendition, source, preparedFiles.errorFile, preparedFiles.typeFile);
+        const env = setVariables(rendition, source, preparedFiles.errorFile, preparedFiles.typeFile, optionsFile);
 
         try {
             // use of spawn() with separate arguments prevents shell/command injection
@@ -73,6 +76,13 @@ class ShellScriptWorker {
                 }
             } else {
                 console.log('No content type information file found');
+            }
+
+            if (await fs.pathExists(optionsFile)) {
+                const options = await fs.readJSON(optionsFile);
+                if (options.postProcess === true) {
+                    rendition.postProcess = true;
+                }
             }
         } catch (err) {
             throw newScriptError(err, preparedFiles.errorFile);
@@ -140,7 +150,7 @@ function newScriptError(err, errorFile) {
     return resultErr;
 }
 
-function setVariables(rendition, source, errorFile, typeFile){
+function setVariables(rendition, source, errorFile, typeFile, optionsFile){
     // inherit environment variables
     const env = Object.create(process.env || {});
 
@@ -148,6 +158,7 @@ function setVariables(rendition, source, errorFile, typeFile){
     env.rendition = stripAnsi(rendition.path);
     env.errorfile = errorFile;
     env.typefile = typeFile;
+    env.optionsfile = optionsFile;
 
     const instructions = rendition.instructions;
 

--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -81,7 +81,7 @@ class ShellScriptWorker {
             if (await fs.pathExists(optionsFile)) {
                 try {
                     const options = await fs.readJSON(optionsFile);
-                    if (options.postProcess === true) {
+                    if (options.postProcess === true || options.postProcess === "true") {
                         rendition.postProcess = true;
                     }
                 // eslint-disable-next-line no-unused-vars

--- a/test/rendition.postprocess.test.js
+++ b/test/rendition.postprocess.test.js
@@ -591,7 +591,6 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
-        await fs.remove("worker.sh");
     });
 
     it("should post process after shellScriptWorker(), json postProcess is string", async () => {
@@ -634,7 +633,6 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
-        await fs.remove("worker.sh");
     });
 
     it("should not post process after shellScriptWorker(), options.json is not formatted correctly", async () => {
@@ -678,6 +676,5 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
-        await fs.remove("worker.sh");
     });
 });


### PR DESCRIPTION
## Description

stores it in `out/options.json`:
```
{
   "postProcess": true
}
```
- must be json (but gracefully handles without failing if its not a json)
- must be boolean `true` and not `"true"` string

Fixes # https://jira.corp.adobe.com/browse/NUI-779

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
