### PR TITLE
NUI-824 dereference symlinks when copying files in test mode

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -77,7 +77,10 @@ async function cleanupDirectories(directories) {
 
         // test-worker framework: copy rendition results to /out mount
         if (process.env.WORKER_TEST_MODE) {
-            await fse.copy(directories.out, "/out");
+            await fse.copy(directories.out, "/out", {
+                // Make sure symlinks are copied as binaries and not symlinks
+                dereference: true
+            });
         }
 
         // should also remove metadata (error and mimetype) files, if not already cleaned

--- a/test-worker/worker.js
+++ b/test-worker/worker.js
@@ -37,7 +37,7 @@ exports.main = worker(async (source, rendition) => {
     } else {
         console.log(`[test worker] copying source to rendition: ${source.path} to ${rendition.path}`);
         // simple case where post processing just runs on the source files for basic tests
-        // copy source to rendition to transfer 1:1
+        // symlink source to rendition to transfer 1:1
         await fs.symlink(source.path, rendition.path);
     }
 

--- a/test-worker/worker.js
+++ b/test-worker/worker.js
@@ -38,7 +38,7 @@ exports.main = worker(async (source, rendition) => {
         console.log(`[test worker] copying source to rendition: ${source.path} to ${rendition.path}`);
         // simple case where post processing just runs on the source files for basic tests
         // copy source to rendition to transfer 1:1
-        await fs.copyFile(source.path, rendition.path);
+        await fs.symlink(source.path, rendition.path);
     }
 
     rendition.postProcess = true;


### PR DESCRIPTION
## Description

bug discovered in `worker-flite` unit tests: https://circle.ci.adobeitc.com/gh/nui/worker-flite/561?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Fixes [NUI-824](https://jira.corp.adobe.com/browse/NUI-824) (point 1).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
