### PR TITLE
increase timeout of test from 2 to 5 sec since it often times out on CircleCI

### DIFF
--- a/test/postprocess.test.js
+++ b/test/postprocess.test.js
@@ -122,7 +122,7 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[0].callbackProcessingDuration + receivedMetrics[0].postProcessingDuration, receivedMetrics[0].processingDuration);
         assert.equal(receivedMetrics[1].eventType, "activation");
         assert.equal(receivedMetrics[1].callbackProcessingDuration + receivedMetrics[1].postProcessingDuration, receivedMetrics[1].processingDuration);
-    });
+    }).timeout(5000);
 
     it('should fail if rendition failed in post processing - single rendition ', async () => {
         //batchworker single rendition post process eligible


### PR DESCRIPTION
While the `should convert PNG to JPG - end to end test` runs fast on Travis CI (~400ms) it runs slower on CircleCI (1500ms+) and often times out, blocking PRs.
Example:
- [travis ci job](https://travis-ci.com/github/adobe/asset-compute-sdk/jobs/394515930)
- [circleci job](https://circle.ci.adobeitc.com/gh/nui/cli/308).

The difference between CircleCI and Travis CI might be explained by different versions of `imagemagick` on them.