### PR TITLE
NUI-855 - Better metrics and logs for post processing

### DIFF
--- a/lib/postprocessing/image.js
+++ b/lib/postprocessing/image.js
@@ -129,6 +129,7 @@ function hasExtraInstructions(instructions) {
 }
 
 async function getImageMetadata(file) {
+    const start = new Date();
     try {
         // [1x1+0+0] is a trick to avoid reading all pixels into memory, improving time for large images
         const result = await gm(`${file}[1x1+0+0]`).write("json:-");
@@ -142,6 +143,8 @@ async function getImageMetadata(file) {
         }
     } catch (e) {
         throw new GenericError(`Reading metadata from intermediate rendition failed: ${e.message}`);
+    } finally {
+        console.log(`imagemagick read metadata command took ${new Date() - start} msec`);
     }
 }
 
@@ -451,8 +454,14 @@ async function write(img, outfile) {
     }
     console.log("imagemagick command:", args.join(" "));
 
-    // actual work will happen inside here as imagemagick only gets invoked upon gm.write()
-    await img.write(outfile);
+    const start = new Date();
+
+    try {
+        // actual work will happen inside here as imagemagick only gets invoked upon gm.write()
+        await img.write(outfile);
+    } finally {
+        console.log(`imagemagick command took ${new Date() - start} msec`);
+    }
 }
 
 /**

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -308,6 +308,7 @@ class AssetComputeWorker {
 
         try {
             if (await this.shouldPostProcess(rendition)) {
+                this.metrics.add({ imagePostProcess: true });
 
                 // at this point, we have the rendition a worker created, available at rendition.path
                 // naming rules are rendition0.extension, rendition1.extension, etc.
@@ -332,6 +333,7 @@ class AssetComputeWorker {
 
             } else {
                 this.timers.postProcessing.stop();
+                this.metrics.add({ imagePostProcess: false });
             }
 
             return rendition;
@@ -451,12 +453,12 @@ class AssetComputeWorker {
                 console.log(`Action is about to timeout in ${utils.timeUntilActivationTimeout()}ms. Sending rendition_failed events before timeout.`);
 
                 this.timers.actionDuration.stop();
-                const errorMessage = `Worker timed out without result after ${this.timers.actionDuration} seconds.`;
 
                 // ensure failure events are sent for any non successful rendition before timeout
                 if (this.renditions) {
                     for (const rendition of this.renditions) {
                         if (!rendition.eventSent) {
+                            const errorMessage = `Processing timed out for rendition fmt='${rendition.fmt}' without result after ${this.timers.actionDuration} seconds.`;
                             rendition.eventSent = true;
                             await this.events.sendEvent(EVENT_RENDITION_FAILED, {
                                 rendition: rendition.instructionsForEvent(),
@@ -472,6 +474,7 @@ class AssetComputeWorker {
                     // send rendition_failed event by default in this case
                     if (this.params && this.params.renditions) {
                         for (const rendition of this.params.renditions) {
+                            const errorMessage = `Processing timed out for rendition fmt='${rendition.fmt}' without result after ${this.timers.actionDuration} seconds.`;
                             // remove target URLs, could be sensitive
                             const renditionCopy = { ...rendition };
                             delete renditionCopy.target;

--- a/test/postprocess.test.js
+++ b/test/postprocess.test.js
@@ -131,6 +131,8 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[0].callbackProcessingDuration + receivedMetrics[0].postProcessingDuration, receivedMetrics[0].processingDuration);
         assert.equal(receivedMetrics[1].eventType, "activation");
         assert.equal(receivedMetrics[1].callbackProcessingDuration + receivedMetrics[1].postProcessingDuration, receivedMetrics[1].processingDuration);
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
     }).timeout(5000);
 
     it('should fail if rendition failed in post processing - single rendition ', async () => {
@@ -174,6 +176,8 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[1].eventType, "activation");
         assert.ok(receivedMetrics[0].callbackProcessingDuration > 0, receivedMetrics[0].postProcessingDuration > 0, receivedMetrics[0].processingDuration > 0);
         assert.ok(receivedMetrics[1].callbackProcessingDuration > 0, receivedMetrics[1].postProcessingDuration > 0, receivedMetrics[1].processingDuration > 0);
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
     });
 
     it('should download source, invoke worker in batch callback and upload rendition - same rendition', async () => {
@@ -247,6 +251,11 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[3].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration, receivedMetrics[1].callbackProcessingDuration, receivedMetrics[2].callbackProcessingDuration);
         assert.equal(receivedMetrics[3].callbackProcessingDuration + receivedMetrics[3].postProcessingDuration, receivedMetrics[3].processingDuration);
         assert.equal(receivedMetrics[0].postProcessingDuration + receivedMetrics[1].postProcessingDuration + receivedMetrics[2].postProcessingDuration, receivedMetrics[3].postProcessingDuration);
+
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
+        assert.equal(receivedMetrics[2].imagePostProcess, true);
+        assert.equal(receivedMetrics[3].imagePostProcess, true);
     });
 
     it('should download source, invoke worker in batch callback and upload rendition - different rendition', async () => {
@@ -362,7 +371,13 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[3].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration);
         assert.equal(receivedMetrics[3].postProcessingDuration, receivedMetrics[0].postProcessingDuration + receivedMetrics[1].postProcessingDuration
                                 + receivedMetrics[2].postProcessingDuration);
+
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
+        assert.equal(receivedMetrics[2].imagePostProcess, true);
+        assert.equal(receivedMetrics[3].imagePostProcess, true);
     });
+
     it('should post process eligible rendition and skip others - multiple rendition', async () => {
         //batchworker multiple rendition not all post process eligible
         const receivedMetrics = MetricsTestHelper.mockNewRelic();
@@ -420,6 +435,11 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[3].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration);
         assert.equal(receivedMetrics[3].postProcessingDuration, receivedMetrics[0].postProcessingDuration + receivedMetrics[1].postProcessingDuration
                             + receivedMetrics[2].postProcessingDuration);
+
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.ok(!receivedMetrics[1].imagePostProcess);
+        assert.equal(receivedMetrics[2].imagePostProcess, true);
+        assert.equal(receivedMetrics[3].imagePostProcess, true);
     });
 
     it('should generate rendition if only one post processing ineligible rendition', async () => {
@@ -464,7 +484,10 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[1].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration);
         assert.equal(receivedMetrics[1].postProcessingDuration, receivedMetrics[0].postProcessingDuration);
         assert.equal(receivedMetrics[1].processingDuration, receivedMetrics[0].processingDuration);
+        assert.ok(!receivedMetrics[0].imagePostProcess);
+        assert.ok(!receivedMetrics[1].imagePostProcess);
     });
+
     it('should generate rendition if only one post processing eligible rendition', async () => {
         const receivedMetrics = MetricsTestHelper.mockNewRelic();
         const events = testUtil.mockIOEvents();
@@ -507,7 +530,10 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[1].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration);
         assert.equal(receivedMetrics[1].postProcessingDuration, receivedMetrics[0].postProcessingDuration);
         assert.equal(receivedMetrics[1].processingDuration, receivedMetrics[0].processingDuration);
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
     });
+
     it('should generate rendition when all rendition are post processing ineligible', async () => {
         const receivedMetrics = MetricsTestHelper.mockNewRelic();
         const events = testUtil.mockIOEvents();
@@ -557,6 +583,9 @@ describe("imagePostProcess", () => {
         assert.equal(receivedMetrics[1].callbackProcessingDuration + receivedMetrics[0].postProcessingDuration, receivedMetrics[0].processingDuration);
         assert.equal(receivedMetrics[2].eventType, "activation");
         assert.equal(receivedMetrics[2].callbackProcessingDuration, receivedMetrics[0].callbackProcessingDuration);
+        assert.ok(!receivedMetrics[0].imagePostProcess);
+        assert.ok(!receivedMetrics[1].imagePostProcess);
+        assert.ok(!receivedMetrics[2].imagePostProcess);
     });
 
     it("should post process after shellScriptWorker(), json postProcess is boolean", async () => {
@@ -598,6 +627,8 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
     });
 
     it("should post process after shellScriptWorker(), json postProcess is string", async () => {
@@ -639,6 +670,8 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
+        assert.equal(receivedMetrics[0].imagePostProcess, true);
+        assert.equal(receivedMetrics[1].imagePostProcess, true);
     });
 
     it("should fail if options.json from shellScriptWorker() is not formatted correctly", async () => {
@@ -682,5 +715,7 @@ describe("imagePostProcess", () => {
 
         await MetricsTestHelper.metricsDone();
         assert.equal(receivedMetrics.length, 2);
+        assert.ok(!receivedMetrics[0].imagePostProcess);
+        assert.ok(!receivedMetrics[1].imagePostProcess);
     });
 });


### PR DESCRIPTION
For [NUI-855](https://jira.corp.adobe.com/browse/NUI-855). I slightly changed that from just `Log the duration of just the imagemagick convert command in post processing` to `Better metrics and logs for post processing` and doing all these small improvements:

- Log the duration of the imagemagick convert command in post processing
- Log the duration of the imagemagick metadata read command in post processing
- Add `imagePostProcess` (boolean) metric if image post processing ran
- Change worker timeout message wording to include fmt not worker name

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
