### PR TITLE
Add codecov.yml to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,7 @@ Jenkinsfile
 .eslintignore
 stryker.conf.js
 build/
+codecov.yml
 
 # npm pack leftovers
 *.tgz


### PR DESCRIPTION
## Description

I noticed the codecov.yml file was in the npm-installed SDK while debugging tests for https://github.com/adobe/asset-compute-sdk/pull/67

Fixes # N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
