### PR TITLE
add sizewatcher to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
 
 after_script:
   - cat test-worker/build/test-results/test-worker/test.log
+  - npx @adobe/sizewatcher
 
 after_success:
   - npm run report-coverage


### PR DESCRIPTION
This updates the travis CI jobs to run [@adobe/sizewatcher](https://github.com/adobe/sizewatcher).

This tool warns if pull requests introduce large size increases (e.g. npm modules dependencies, package size etc.).

Additional change:
- ensure `GITHUB_TOKEN` (with adobe-bot token) is set in Travis CI settings, for all branches.