### PR TITLE
NUI-914 Update package.json - Prepare 2.10.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@adobe/asset-compute-sdk",
   "description": "Adobe Asset Compute Worker SDK",
   "license": "Apache-2.0",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "author": {
     "name": "Adobe Inc."
   },


### PR DESCRIPTION
For NUI-914 release.

Update package.json - Prepare 2.10.0 release.
It seems cascading release encountered an issue and cannot do the automated release. So here we are...