### PR TITLE
fix failing unit tests, file command

### DIFF
--- a/test/rendition.test.js
+++ b/test/rendition.test.js
@@ -367,7 +367,7 @@ describe("rendition.js", () => {
             // overwrite path to point to test files
             rendition.path = './test/files/file.bmp';
             const result = await rendition.mimeType();
-            assert.strictEqual(result, 'image/bmp');
+            assert.ok(result === 'image/bmp' || result === 'image/x-ms-bmp');
         });
 
         it('gracefully handles not finding files when identifying mimetype', async function () {

--- a/test/rendition.test.js
+++ b/test/rendition.test.js
@@ -367,7 +367,7 @@ describe("rendition.js", () => {
             // overwrite path to point to test files
             rendition.path = './test/files/file.bmp';
             const result = await rendition.mimeType();
-            assert.strictEqual(result, 'image/x-ms-bmp');
+            assert.strictEqual(result, 'image/bmp');
         });
 
         it('gracefully handles not finding files when identifying mimetype', async function () {

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -21,10 +21,9 @@ const mockRequire = require("mock-require");
 
 describe("type.js", () => {
     it('detects mimetypes and encodings', async function () {
-        assert.deepStrictEqual(await detectContentType('./test/files/file.bmp'), {
-            mime: 'image/bmp',
-            encoding: "binary"
-        });
+        const result = await detectContentType('./test/files/file.bmp');
+        assert.ok(result.mime === 'image/bmp' || result.mime === 'image/x-ms-bmp');
+        assert.ok(result.encoding === 'binary');
 
         assert.deepStrictEqual(await detectContentType('./test/files/file.tif'), {
             mime: 'image/tiff',

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -22,7 +22,7 @@ const mockRequire = require("mock-require");
 describe("type.js", () => {
     it('detects mimetypes and encodings', async function () {
         assert.deepStrictEqual(await detectContentType('./test/files/file.bmp'), {
-            mime: 'image/x-ms-bmp',
+            mime: 'image/bmp',
             encoding: "binary"
         });
 


### PR DESCRIPTION
## Description

newer `file` command now returns `image/bmp` for the bmp file. I even tried it locally:
```
$ file -b --mime /Users/jamiedelbick/work/adobe/asset-compute-sdk/test/files/file.bmp                     
image/bmp; charset=binary
``` 

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
