### PR TITLE
NUI-1275 implementation manifest to its own file

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -151,16 +151,13 @@ function shellScriptWorker(script = "worker.sh", options = {}) {
 }
 
 async function buildTransformers(renditionCallback, options={}) {
-    const transformers = [];
     if (!options.manifest) {
-        return transformers;
+        return [];
     }
-    
     debug('Manifest', options.manifest);
     const transformer = new WorkerCallbackTransformer(renditionCallback, options.manifest);
     debug(`Created a transformer named ${transformer.name}`);
-    transformers.push(transformer);
-    return transformers.concat(options.transformerCatalog);
+    return [transformer, ...options.transformerCatalog];
 }
 
 module.exports = {

--- a/lib/api.js
+++ b/lib/api.js
@@ -152,22 +152,15 @@ function shellScriptWorker(script = "worker.sh", options = {}) {
 
 async function buildTransformers(renditionCallback, options={}) {
     const transformers = [];
-
-    if (!options.manifests) {
+    if (!options.manifest) {
         return transformers;
     }
-
-    const manifests = options.manifests;
-    console.log('Manifest array', manifests);
-
-    manifests.forEach(oneManifest => {
-        const oneTransformer = new WorkerCallbackTransformer(renditionCallback, oneManifest);
-        debug(`Created a transformer named ${oneTransformer.name} with manifest:`);
-        debug(oneManifest);
-        transformers.push(oneTransformer);
-    });
-    return transformers.concat(options.transformerCatalog);
     
+    debug('Manifest', options.manifest);
+    const transformer = new WorkerCallbackTransformer(renditionCallback, options.manifest);
+    debug(`Created a transformer named ${transformer.name}`);
+    transformers.push(transformer);
+    return transformers.concat(options.transformerCatalog);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "nock": "^13.0.11",
     "nyc": "^15.1.0",
     "read-chunk": "^3.2.0",
+    "rewire": "^5.0.0",
     "rimraf": "^3.0.2",
     "semantic-release": "^17.4.2",
     "sinon": "^10.0.0"

--- a/test-worker/pipeline-manifest.json
+++ b/test-worker/pipeline-manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "sdkTestWorker",
+    "inputs": {
+        "type": ["image/jpeg", "image/png"]
+    },
+    "outputs": {
+        "type": ["image/jpeg", "image/png"]
+    }
+}

--- a/test-worker/worker.js
+++ b/test-worker/worker.js
@@ -16,7 +16,6 @@
 
 const { worker, GenericError } = require('../index');
 const gm = require("../lib/postprocessing/gm-promisify");
-const { Manifest } = require("@adobe/asset-compute-pipeline");
 const { SenseiCatalog } = require("@nui/transformer-sensei/transformer-catalog.js");
 
 const fs = require('fs').promises;
@@ -70,15 +69,5 @@ exports.main = worker(async (source, rendition) => {
 }, {
     supportedRenditionFormats: SUPPORTED_FMT,
     transformerCatalog: new SenseiCatalog().catalog,
-    manifests: [
-        new Manifest({
-            "name": "sdkTestWorker",
-            "inputs": {
-                "type": ["image/jpeg", "image/png"]
-            },
-            "outputs": {
-                "type": ["image/jpeg", "image/png"]
-            }
-        })
-    ]
+    manifest: require("./pipeline-manifest.json")
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -779,6 +779,15 @@ describe("api.js", () => {
             await testUtil.assertSimpleParamsMetrics(receivedMetrics);
         });
 
+        it.skip('pipeline: should not return transformers if no manifest file found', async () => {
+            const rewire = require('rewire');
+            const rewiredApi  = rewire('../lib/api');
+            const buildTransformers = rewiredApi.__get__('buildTransformers');
+
+            const transformers = await buildTransformers({});
+            assert.strictEqual(transformers,[]);
+        });
+
     });
 
     describe("batchWorker()", () => {


### PR DESCRIPTION
For https://jira.corp.adobe.com/browse/NUI-1275 [design decision + impl] decide how to import multiple manifest files into workers

Based on our discussion at the end of the mob(with Alex), reverting some of our changes from our mob yesterday.
- Make manifest a separate file.


## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
