### PR TITLE
NUI-1347 [sdk] map nui fmt to mimetype in source and rendition instructions (pipeline only)

### DIFF
--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -82,7 +82,13 @@ class AssetComputeWorkerPipeline {
         }
 
         // source.mimetype will always exist, no need to cultivate here.
-        input.type = input.mimetype && input.mimetype.toLowerCase();
+        const type = input.mimetype && input.mimetype.toLowerCase();
+        // make source mimetypes align to Manifest
+        const SOURCE_TYPE_MAP = {
+            "image/jpg" : "image/jpeg",
+            "image/tif" : "image/tiff"
+        };
+        input.type = SOURCE_TYPE_MAP[type] || (type && type.toLowerCase());
 
         if(!input.type || !output.type) {
             //TODO should throw ClientError ?

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -71,9 +71,8 @@ class AssetComputeWorkerPipeline {
     }
 
     normalizeInputOuput(input, output) {
-        console.log('input before normalization: ', input);
-        console.log('outpu before normalization: ', output);
-
+        // TODO: we will have special cases for beta-worker-creative 
+        // special case for sensei
         if(output.fmt === 'machine-metadata-json') {
             output.type = 'machine-metadata-json';
         } else {
@@ -85,10 +84,9 @@ class AssetComputeWorkerPipeline {
         // source.mimetype will always exist, no need to cultivate here.
         input.type = input.mimetype && input.mimetype.toLowerCase();
 
-        console.log('input after normalization: ', input);
-        console.log('outpu after normalization: ', output);
         // TODO: throw if params.source.type || rendition.type does not exist
         if(!input.type || !output.type) {
+            //TODO should throw ClientError ?
             console.log("Pipeline won't be able to find a plan and will throw error");
         }
     }

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -18,6 +18,7 @@ const WorkerCallbackTransformer = require('./worker-transformer');
 
 const fs = require('fs-extra');
 const path = require('path');
+const mime = require('mime-types');
 
 /**
  * Represents a pipeline build around a worker callback.
@@ -69,6 +70,29 @@ class AssetComputeWorkerPipeline {
         return engine;
     }
 
+    normalizeInputOuput(input, output) {
+        console.log('input before normalization: ', input);
+        console.log('outpu before normalization: ', output);
+
+        if(output.fmt === 'machine-metadata-json') {
+            output.type = 'machine-metadata-json';
+        } else {
+            // rendition.fmt should always exist
+            const mimetype = mime.lookup(output.fmt.toLowerCase());
+            output.type = mimetype && mimetype.toLowerCase();
+        }
+
+        // source.mimetype will always exist, no need to cultivate here.
+        input.type = input.mimetype && input.mimetype.toLowerCase();
+
+        console.log('input after normalization: ', input);
+        console.log('outpu after normalization: ', output);
+        // TODO: throw if params.source.type || rendition.type does not exist
+        if(!input.type || !output.type) {
+            console.log("Pipeline won't be able to find a plan and will throw error");
+        }
+    }
+
     async compute(params){
         const engine = this.prepareEngine(params);
         debug("Created pipeline engine");
@@ -108,12 +132,15 @@ class AssetComputeWorkerPipeline {
             };
             debug('######### input:', input);
         }
+        const output = params.renditions[0];
+        // normalize source and rendition
+        this.normalizeInputOuput(input, output);
 
         // TODO we will need to add support for multiple renditions
         // TODO we have to integrate options into our plan and support everything we support now
         
         debug("Preparing plan for rendition creation...");
-        engine.refinePlan(plan, input, params.renditions[0]);
+        engine.refinePlan(plan, input, output);
         debug("Refined plan to create rendition");
 
         debug("Running pipeline...");

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -84,7 +84,6 @@ class AssetComputeWorkerPipeline {
         // source.mimetype will always exist, no need to cultivate here.
         input.type = input.mimetype && input.mimetype.toLowerCase();
 
-        // TODO: throw if params.source.type || rendition.type does not exist
         if(!input.type || !output.type) {
             //TODO should throw ClientError ?
             console.log("Pipeline won't be able to find a plan and will throw error");

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Adobe. All rights reserved.
+ * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -205,17 +205,30 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
         assert.strictEqual(output.type,'machine-metadata-json');
     });
+
+    it("should not error for invalid fmt", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.psd",
+            mimetype: "image/vnd.adobe.photoshop"
+        };
+        const output = {
+            target: "https://example.com/target.invalid",
+            name: "cq.dam.319x319.invalid",
+            fmt: "invalid"
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
+        assert.strictEqual(output.type,false);
+    });
     it("should map type: worker-test", async () => {
         
         const input = {
             path: 'test-folder-in/file.png'
-            // url: "https://adobe.com",
-            // name: "source.psd",
-            // mimetype: "image/vnd.adobe.photoshop"
         };
         const output = {
-            // target: "https://example.com/target.jpeg",
-            // name: "cq.dam.319x319.jpeg",
             fmt: "png"
                 
         };

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint mocha/no-mocha-arrows: "off" */
+
+'use strict';
+
+const { AssetComputeWorkerPipeline } = require('../lib/worker-pipeline.js');
+
+const process = require('process');
+const assert = require('assert');
+const sinon = require('sinon');
+
+describe("worker-pipeline.js", () => {
+    it("should lookup type: source-mime:png rendition-fmt:png", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.png",
+            mimetype: "image/png"
+        };
+        const output = {
+            target: "https://example.com/target.png",
+            name: "cq.dam.319x319.png",
+            fmt: "png"
+        };
+        
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/png');
+        assert.strictEqual(output.type,'image/png');
+    });
+    it("should lookup type: source-mime:png rendition-fmt:jpg", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.png",
+            mimetype: "image/png"
+        };
+        const output = {
+            target: "https://example.com/target.jpg",
+            name: "cq.dam.319x319.jpg",
+            fmt: "jpg"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/png');
+        assert.strictEqual(output.type,'image/jpeg');
+    });
+    it("should lookup type: source-mime:jpeg rendition-fmt:jpeg (JPEG-JPG synonym)", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.jpeg",
+            mimetype: "image/jpeg"
+        };
+        const output = {
+            target: "https://example.com/target.jpeg",
+            name: "cq.dam.319x319.jpeg",
+            fmt: "jpeg"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/jpeg');
+        assert.strictEqual(output.type,'image/jpeg');
+    });
+
+    it("should lookup type: source-mime:tiff rendition-fmt:tif (tiff-tif synonym)", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.tiff",
+            mimetype: "image/tiff"
+        };
+        const output = {
+            target: "https://example.com/target.tif",
+            name: "cq.dam.319x319.tif",
+            fmt: "tif"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/tiff');
+        assert.strictEqual(output.type,'image/tiff');
+    });
+
+    it("should lookup type: source-mime:tiff rendition-fmt:tiff (tiff-tif synonym)", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.tiff",
+            mimetype: "image/tiff"
+        };
+        const output = {
+            target: "https://example.com/target.tiff",
+            name: "cq.dam.319x319.tiff",
+            fmt: "tiff"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/tiff');
+        assert.strictEqual(output.type,'image/tiff');
+    });
+
+    it("should lookup type: source-mime:bmp rendition-fmt:gif", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.bmp",
+            mimetype: "image/bmp"
+        };
+        const output = {
+            target: "https://example.com/target.bmp",
+            name: "cq.dam.319x319.gif",
+            fmt: "gif"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/bmp');
+        assert.strictEqual(output.type,'image/gif');
+    });
+
+    it("should lookup type: source-mime:gif rendition-fmt:tif", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.gif",
+            mimetype: "image/gif"
+        };
+        const output = {
+            target: "https://example.com/target.tif",
+            name: "cq.dam.319x319.tif",
+            fmt: "tif"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/gif');
+        assert.strictEqual(output.type,'image/tiff');
+    });
+    it("should lookup type: source-mime:psd rendition-fmt:psd", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.psd",
+            mimetype: "image/vnd.adobe.photoshop"
+        };
+        const output = {
+            target: "https://example.com/target.psd",
+            name: "cq.dam.319x319.psd",
+            fmt: "psd"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
+        assert.strictEqual(output.type,'image/vnd.adobe.photoshop');
+    });
+    it("should lookup type: source-mime:psd rendition-fmt:jpeg", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.psd",
+            mimetype: "image/vnd.adobe.photoshop"
+        };
+        const output = {
+            target: "https://example.com/target.jpeg",
+            name: "cq.dam.319x319.jpeg",
+            fmt: "jpeg"
+
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
+        assert.strictEqual(output.type,'image/jpeg');
+    });
+    it("should map type: source-mime:psd rendition-fmt:machine-metadata-json", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.psd",
+            mimetype: "image/vnd.adobe.photoshop"
+        };
+        const output = {
+            target: "https://example.com/target.jpeg",
+            name: "cq.dam.319x319.jpeg",
+            fmt: "machine-metadata-json"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
+        assert.strictEqual(output.type,'machine-metadata-json');
+    });
+    it("should map type: worker-test", async () => {
+        
+        const input = {
+            path: 'test-folder-in/file.png'
+            // url: "https://adobe.com",
+            // name: "source.psd",
+            // mimetype: "image/vnd.adobe.photoshop"
+        };
+        const output = {
+            // target: "https://example.com/target.jpeg",
+            // name: "cq.dam.319x319.jpeg",
+            fmt: "png"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,undefined);
+        assert.strictEqual(output.type,'image/png');
+    });
+});

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -94,6 +94,24 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/tiff');
         assert.strictEqual(output.type,'image/tiff');
     });
+    it("should lookup type: source-mime:tif rendition-fmt:tif (tiff-tif synonym)", async () => {
+        const input = {
+            url: "https://adobe.com",
+            name: "source.tif",
+            mimetype: "image/tif"
+        };
+        const output = {
+            target: "https://example.com/target.tif",
+            name: "cq.dam.319x319.tif",
+            fmt: "tif"
+                
+        };
+
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/tiff');
+        assert.strictEqual(output.type,'image/tiff');
+    });
 
     it("should lookup type: source-mime:tiff rendition-fmt:tiff (tiff-tif synonym)", async () => {
         const input = {

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -17,9 +17,7 @@
 
 const { AssetComputeWorkerPipeline } = require('../lib/worker-pipeline.js');
 
-const process = require('process');
 const assert = require('assert');
-const sinon = require('sinon');
 
 describe("worker-pipeline.js", () => {
     it("should lookup type: source-mime:png rendition-fmt:png", async () => {
@@ -39,6 +37,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/png');
         assert.strictEqual(output.type,'image/png');
     });
+
     it("should lookup type: source-mime:png rendition-fmt:jpg", async () => {
         const input = {
             url: "https://adobe.com",
@@ -48,8 +47,7 @@ describe("worker-pipeline.js", () => {
         const output = {
             target: "https://example.com/target.jpg",
             name: "cq.dam.319x319.jpg",
-            fmt: "jpg"
-                
+            fmt: "jpg"            
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -57,6 +55,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/png');
         assert.strictEqual(output.type,'image/jpeg');
     });
+
     it("should lookup type: source-mime:jpeg rendition-fmt:jpeg (JPEG-JPG synonym)", async () => {
         const input = {
             url: "https://adobe.com",
@@ -67,7 +66,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.jpeg",
             name: "cq.dam.319x319.jpeg",
             fmt: "jpeg"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -86,7 +84,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.tif",
             name: "cq.dam.319x319.tif",
             fmt: "tif"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -94,6 +91,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/tiff');
         assert.strictEqual(output.type,'image/tiff');
     });
+
     it("should lookup type: source-mime:tif rendition-fmt:tif (tiff-tif synonym)", async () => {
         const input = {
             url: "https://adobe.com",
@@ -104,7 +102,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.tif",
             name: "cq.dam.319x319.tif",
             fmt: "tif"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -123,7 +120,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.tiff",
             name: "cq.dam.319x319.tiff",
             fmt: "tiff"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -142,7 +138,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.bmp",
             name: "cq.dam.319x319.gif",
             fmt: "gif"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -161,7 +156,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.tif",
             name: "cq.dam.319x319.tif",
             fmt: "tif"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -169,6 +163,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/gif');
         assert.strictEqual(output.type,'image/tiff');
     });
+
     it("should lookup type: source-mime:psd rendition-fmt:psd", async () => {
         const input = {
             url: "https://adobe.com",
@@ -179,7 +174,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.psd",
             name: "cq.dam.319x319.psd",
             fmt: "psd"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -187,6 +181,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
         assert.strictEqual(output.type,'image/vnd.adobe.photoshop');
     });
+
     it("should lookup type: source-mime:psd rendition-fmt:jpeg", async () => {
         const input = {
             url: "https://adobe.com",
@@ -197,7 +192,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.jpeg",
             name: "cq.dam.319x319.jpeg",
             fmt: "jpeg"
-
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -205,6 +199,7 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
         assert.strictEqual(output.type,'image/jpeg');
     });
+
     it("should map type: source-mime:psd rendition-fmt:machine-metadata-json", async () => {
         const input = {
             url: "https://adobe.com",
@@ -215,7 +210,6 @@ describe("worker-pipeline.js", () => {
             target: "https://example.com/target.jpeg",
             name: "cq.dam.319x319.jpeg",
             fmt: "machine-metadata-json"
-                
         };
 
         const testPipelineWorker = new AssetComputeWorkerPipeline();
@@ -235,12 +229,12 @@ describe("worker-pipeline.js", () => {
             name: "cq.dam.319x319.invalid",
             fmt: "invalid"
         };
-
         const testPipelineWorker = new AssetComputeWorkerPipeline();
         testPipelineWorker.normalizeInputOuput(input, output);
         assert.strictEqual(input.type,'image/vnd.adobe.photoshop');
         assert.strictEqual(output.type,false);
     });
+    
     it("should map type: worker-test", async () => {
         
         const input = {


### PR DESCRIPTION
For https://jira.corp.adobe.com/browse/NUI-1347 [sdk] map nui fmt to mimetype in source and rendition instructions (pipeline only)

- Adds mapping to populate input.type & output.type for pipeline flow.
- Adds test cases for all pipeline MVP formats/source combinations


## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
