### PR TITLE
NUI-1378 add fallback for source mimetype detection if headers request does not get correct mimetype

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -37,9 +37,9 @@ function worker(renditionCallback, options = {}) {
     return actionWrapper(async function (params) {
     
         // Debug: Use sleep to ensure tests have time to grab logs
-        const { promisify } = require('util');
-        const sleep = promisify(setTimeout);
-        await sleep(2000);
+        // const { promisify } = require('util');
+        // const sleep = promisify(setTimeout);
+        // await sleep(2000);
         console.log("## worker(renditionCallback) -> actionWrapper");
         //*/
 

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -156,8 +156,8 @@ class AssetComputeWorkerPipeline {
         const output = params.renditions[0];
         // normalize source and rendition
         this.normalizeInputOuput(input, output);
-        debug(`Input for refinePlan: ${input}`);
-        debug(`Output for refinePlan: ${output}`);
+        debug(`Input for refinePlan: ${JSON.stringify(input, null, 1)}`);
+        debug(`Output for refinePlan: ${JSON.stringify(output, null, 1)}`);
         // TODO we will need to add support for multiple renditions
         // TODO we have to integrate options into our plan and support everything we support now
         

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -93,6 +93,7 @@ class AssetComputeWorkerPipeline {
         // this can happen if the client (for example the devtool) does not define the content-type correctly
         let type;
         if ((!input.mimetype || input.mimetype === DEFAULT_MIMETYPE) && input.name) {
+            debug(`Looking up mimetype from input: ${input.mimetype}`);
             const inputExtension = path.extname(input.name);
             const inputMimetype = mime.lookup(inputExtension.toLowerCase());
             type = (inputMimetype && inputMimetype.toLowerCase()) || DEFAULT_MIMETYPE;
@@ -105,7 +106,7 @@ class AssetComputeWorkerPipeline {
         }
 
         if(!input.type || !output.type) {
-            // plan alg with throw error and send io events
+            // plan alg will throw error and send io events
             console.log("Pipeline won't be able to find a plan and will throw error");
         }
     }

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -20,6 +20,13 @@ const fs = require('fs-extra');
 const path = require('path');
 const mime = require('mime-types');
 
+// make source mimetypes align to Manifest
+const SOURCE_TYPE_MAP = {
+    "image/jpg" : "image/jpeg",
+    "image/tif" : "image/tiff"
+};
+const DEFAULT_MIMETYPE = 'application/octet-stream';
+
 /**
  * Represents a pipeline build around a worker callback.
  * Mostly here for backwards compatibility.
@@ -81,19 +88,24 @@ class AssetComputeWorkerPipeline {
             output.type = mimetype && mimetype.toLowerCase();
         }
 
-        // source.mimetype will always exist, no need to cultivate here.
-        const type = input.mimetype && input.mimetype.toLowerCase();
-        // make source mimetypes align to Manifest
-        const SOURCE_TYPE_MAP = {
-            "image/jpg" : "image/jpeg",
-            "image/tif" : "image/tiff"
-        };
+        // if source.mimetype does not exist, or it does not match the extension,
+        // try to find mimetype by mapping the extension
+        // this can happen if the client (for example the devtool) does not define the content-type correctly
+        let type;
+        if ((!input.mimetype || input.mimetype === DEFAULT_MIMETYPE) && input.name) {
+            const inputExtension = path.extname(input.name);
+            const inputMimetype = mime.lookup(inputExtension.toLowerCase());
+            type = (inputMimetype && inputMimetype.toLowerCase()) || DEFAULT_MIMETYPE;
+        } else {
+            type = input.mimetype && input.mimetype.toLowerCase();
+        }
+
         if (type) {
             input.type = SOURCE_TYPE_MAP[type] || (type && type.toLowerCase());
         }
 
         if(!input.type || !output.type) {
-            //TODO should throw ClientError ?
+            // plan alg with throw error and send io events
             console.log("Pipeline won't be able to find a plan and will throw error");
         }
     }
@@ -139,11 +151,12 @@ class AssetComputeWorkerPipeline {
             const inputExtension = path.extname(params.source);
             const inputMimetype = mime.lookup(inputExtension.toLowerCase());
             input.mimetype = inputMimetype && inputMimetype.toLowerCase();
-            debug('######### input:', input);
         }
         const output = params.renditions[0];
         // normalize source and rendition
         this.normalizeInputOuput(input, output);
+        debug(`Input for refinePlan: ${input}`);
+        debug(`Output for refinePlan: ${output}`);
         // TODO we will need to add support for multiple renditions
         // TODO we have to integrate options into our plan and support everything we support now
         

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -145,7 +145,8 @@ class AssetComputeWorkerPipeline {
 
             // update input accordingly
             input = {
-                path: `${testDir}/${params.source}`
+                path: `${testDir}/${params.source}`,
+                name: params.source
             };
 
             const inputExtension = path.extname(params.source);

--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -156,6 +156,7 @@ class AssetComputeWorkerPipeline {
         const output = params.renditions[0];
         // normalize source and rendition
         this.normalizeInputOuput(input, output);
+        // TODO: type check to make sure input/output are objects so we don't throw here if they are not?
         debug(`Input for refinePlan: ${JSON.stringify(input, null, 1)}`);
         debug(`Output for refinePlan: ${JSON.stringify(output, null, 1)}`);
         // TODO we will need to add support for multiple renditions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,14 +1141,15 @@
       }
     },
     "@nui/asset-compute-pipeline": {
-      "version": "0.1.0",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-nui-release-local/@nui/asset-compute-pipeline/-/@nui/asset-compute-pipeline-0.1.0.tgz",
-      "integrity": "sha1-GOP0ihw2wg8hMwB0xSZ3mEEjjW8=",
+      "version": "0.1.1",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-nui-release-local/@nui/asset-compute-pipeline/-/@nui/asset-compute-pipeline-0.1.1.tgz",
+      "integrity": "sha1-652rmPPXX/uTETb6irOke5wA8oo=",
       "requires": {
         "@adobe/aio-lib-files": "^2.1.1",
         "@adobe/asset-compute-commons": "^1.1.2",
         "@adobe/httptransfer": "^2.0.3",
         "@nui/node-sensei-sdk": "^1.5.1",
+        "css-unit-converter": "^1.1.2",
         "data-uri-to-buffer": "^3.0.1",
         "debug": "^4.3.1",
         "file-type": "^16.4.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@adobe/httptransfer": "^2.1.1",
     "@adobe/metrics-sampler": "^1.0.2",
     "@adobe/node-fetch-retry": "^1.1.1",
-    "@nui/asset-compute-pipeline": "^0.1.0",
+    "@nui/asset-compute-pipeline": "^0.1.1",
     "ajv": "6.12.3",
     "clone": "^2.1.2",
     "content-type": "^1.0.4",

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -20,6 +20,9 @@ const { AssetComputeWorkerPipeline } = require('../lib/worker-pipeline.js');
 const assert = require('assert');
 
 describe("worker-pipeline.js", () => {
+    afterEach(() => {
+        delete process.env.WORKER_TEST_MODE;
+    });
     it("should lookup type: source-mime:png rendition-fmt:png", async () => {
         const input = {
             url: "https://adobe.com",
@@ -236,7 +239,6 @@ describe("worker-pipeline.js", () => {
     });
     
     it("should map type: worker-test", async () => {
-        
         const input = {
             path: 'test-folder-in/file.png'
         };
@@ -244,10 +246,53 @@ describe("worker-pipeline.js", () => {
             fmt: "png"
                 
         };
-
         const testPipelineWorker = new AssetComputeWorkerPipeline();
         testPipelineWorker.normalizeInputOuput(input, output);
         assert.strictEqual(input.type,undefined);
+        assert.strictEqual(output.type,'image/png');
+    });
+    it("should get type from extension if input.mimetype is not defined", async () => {
+        process.env.WORKER_TEST_MODE = true;
+        const input = {
+            name: 'file.png'
+        };
+        const output = {
+            fmt: "png"
+                
+        };
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/png');
+        assert.strictEqual(output.type,'image/png');
+    });
+    it("should get type from extension if input.mimetype is not correct", async () => {
+        process.env.WORKER_TEST_MODE = true;
+        const input = {
+            name: 'file.png',
+            mimetype: 'application/octet-stream'
+        };
+        const output = {
+            fmt: "png"
+                
+        };
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'image/png');
+        assert.strictEqual(output.type,'image/png');
+    });
+    it("should try get type from extension if input.mimetype is the default value", async () => {
+        process.env.WORKER_TEST_MODE = true;
+        const input = {
+            name: 'file',
+            mimetype: 'application/octet-stream'
+        };
+        const output = {
+            fmt: "png"
+                
+        };
+        const testPipelineWorker = new AssetComputeWorkerPipeline();
+        testPipelineWorker.normalizeInputOuput(input, output);
+        assert.strictEqual(input.type,'application/octet-stream');
         assert.strictEqual(output.type,'image/png');
     });
 });

--- a/test/worker-pipeline.test.js
+++ b/test/worker-pipeline.test.js
@@ -252,7 +252,6 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(output.type,'image/png');
     });
     it("should get type from extension if input.mimetype is not defined", async () => {
-        process.env.WORKER_TEST_MODE = true;
         const input = {
             name: 'file.png'
         };
@@ -266,7 +265,6 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(output.type,'image/png');
     });
     it("should get type from extension if input.mimetype is not correct", async () => {
-        process.env.WORKER_TEST_MODE = true;
         const input = {
             name: 'file.png',
             mimetype: 'application/octet-stream'
@@ -281,7 +279,6 @@ describe("worker-pipeline.js", () => {
         assert.strictEqual(output.type,'image/png');
     });
     it("should try get type from extension if input.mimetype is the default value", async () => {
-        process.env.WORKER_TEST_MODE = true;
         const input = {
             name: 'file',
             mimetype: 'application/octet-stream'


### PR DESCRIPTION
## Description

As discussed in slack and run into during the mob, we need to have a fallback in case the client does not correctly identify the mimetype. 
Future: 
- move this fallback to `core` and use file identification tools and custom mimetype mapping
- fix bug in devtool putting invalid content-type on source files

Fixes # https://jira.corp.adobe.com/browse/NUI-1378

### Testing
deployed `worker-flite` with sdk `npm link`'d to IT package: `it-20210614-nui-core-f2fc46be4585` and tested with meahana:
<img width="1751" alt="meahana" src="https://user-images.githubusercontent.com/20048485/122474950-c3076900-cf78-11eb-811a-d3eaa1ec709d.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
