### PR TITLE
NUI-1380 backwards compatibility: auth params should be available for transformers

### DIFF
--- a/lib/worker-pipeline.js
+++ b/lib/worker-pipeline.js
@@ -136,6 +136,7 @@ class AssetComputeWorkerPipeline {
         debug("Created initial plan");
 
         let input = params.source;
+        input.auth = params.auth;
 
         // WORKER_TEST_MODE: 
         // for test-worker framework, input and output are mounted at /in and /out


### PR DESCRIPTION
In DRAFT: testing via Devtool pending

NUI-1380 backwards compatibility: auth params should be available for transformers
- https://git.corp.adobe.com/nui/transformer-sensei/pull/27
- https://git.corp.adobe.com/nui/asset-compute-pipeline/pull/30

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
