### PR TITLE
Add `renditionCount` and `totalRenditionsSize` metrics to activation metrics

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -68,7 +68,8 @@ class AssetComputeWorker {
         this.metrics.add({
             startWorkerDuration: Utils.durationSec(this.processingStartTime, this.workerStartTime),
             gatewayToProcessDuration: Utils.durationSec(this.params.times.gateway, this.params.times.process),
-            processToCoreDuration: Utils.durationSec(this.params.times.process, this.params.times.core)
+            processToCoreDuration: Utils.durationSec(this.params.times.process, this.params.times.core),
+            renditionCount: this.params.renditions && this.params.renditions.length
         });
 
         this.timers = {
@@ -78,6 +79,7 @@ class AssetComputeWorker {
             postProcessing:     new Timer(),
             upload:             new Timer()
         };
+        this.totalRenditionsSize = 0;
     }
 
     async compute(renditionCallback) {
@@ -392,6 +394,10 @@ class AssetComputeWorker {
 
         rendition.eventSent = true;
 
+        const renditionSize = rendition.size();
+        // track total rendition size to add to activation metrics
+        this.totalRenditionsSize += renditionSize;
+
         await this.metrics.sendMetrics(METRIC_RENDITION, {
             // rendition instructions
             ...instructions,
@@ -405,7 +411,7 @@ class AssetComputeWorker {
             uploadDuration: this.timers.upload.currentDuration(),
             renditionDuration: Utils.durationSec(this.processingStartTime, renditionDoneTime),
             // rendition metadata
-            size: rendition.size()
+            size: renditionSize
         });
     }
 
@@ -548,7 +554,8 @@ class AssetComputeWorker {
             callbackProcessingDuration: this.timers.processingCallback.totalDuration(),
             postProcessingDuration: this.timers.postProcessing.totalDuration(),
             processingDuration: Timer.totalSum(this.timers.processingCallback, this.timers.postProcessing),
-            uploadDuration: this.timers.upload.totalDuration()
+            uploadDuration: this.timers.upload.totalDuration(),
+            totalRenditionsSize: this.totalRenditionsSize
         });
 
         // if data clean up fails (leftover directories),

--- a/test/testutil.js
+++ b/test/testutil.js
@@ -224,6 +224,8 @@ async function assertSimpleParamsMetrics(receivedMetrics, options={}) {
     }]);
     MetricsTestHelper.assertArrayContains(receivedMetrics, [{
         eventType: "activation",
+        totalRenditionsSize: RENDITION_CONTENT.length,
+        renditionCount: 1
     }]);
 
     assertDurationMetrics(receivedMetrics);
@@ -332,7 +334,9 @@ async function assertParamsWithMultipleRenditions(receivedMetrics) {
         sourceSize: 14,
         requestId: "test-request-id"
     },{
-        eventType: "activation"
+        eventType: "activation",
+        renditionCount: 3,
+        totalRenditionsSize: RENDITION_CONTENT.length * 3
     }]);
 
     assertDurationMetrics(receivedMetrics);


### PR DESCRIPTION
## Description

As we start to work on optimization, we may find the need to look at historical data in new relic to make informed decisions. I noticed a few missing metrics that could help, so I am adding them now so we can start gathering data.

`renditionCount`: number of renditions attempted for processing
- this was only available in `process` metrics until now. If we look at action duration without knowing the amount of renditions, our decisions may have high variance. The number of renditions has a large impact on the action duration.

`totalRenditionsSize`: sum of the size of each rendition successfully produce
- I thought it would be interesting to track this. It is highly related to rendition count, but I see it as a helpful thing to look for, especially in workers that produce larger renditions like transcoding

The idea is if we have all the metrics we need in one event type, we can more easily analyze it. New Relic does not have a `join` clause to merge data between event types (ie no way to merge rendition and activation metric types on the same activation id).

Another interesting metric to add to activation metrics could be `renditionErrorCount`
### Testing
- added to unit test metrics check
- checked metrics from IT test integration: https://onenr.io/0BoQDZ084Ry
   - note: still need to duplicate the changes in pipeline

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
