### PR TITLE
[ASSETS-6954] Use color profile file if available

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
-        node-version: [12.16, 12.19, 14.16.1, 14.17]
+        node-version: [12.16, 12.19, 14.16.1, 14.17, 16.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/postprocessing/image.js
+++ b/lib/postprocessing/image.js
@@ -93,6 +93,8 @@ const EXTRA_INSTRUCTIONS = new Set([
     "watermark"
 ]);
 
+const SRGB_COLOR_PROFILE_FILE = process.env.SRGB_COLOR_PROFILE_FILE;
+
 function isSupportedOutputFormat(fmt) {
     return Object.keys(SUPPORTED_OUTPUT_FMT).includes(fmt);
 }
@@ -561,7 +563,14 @@ async function applyOutputProperties(img, instructions) {
     }
 
     // Most asset compute renditions are used in digital display context (web, screens), where RGB is required
-    img.colorspace('sRGB');
+    if(SRGB_COLOR_PROFILE_FILE){
+        console.log(`Using sRGB profile file: ${SRGB_COLOR_PROFILE_FILE}`);
+        img.profile(SRGB_COLOR_PROFILE_FILE);
+    } else {
+        console.log(`Using default imagemagick sRGB colorspace`);
+        img.colorspace('sRGB');
+    }
+
 
     // for tests only, to be able to easily detect if post processing ran or not
     if (process.env.SDK_POST_PROCESSING_TEST_MODE) {

--- a/lib/postprocessing/image.js
+++ b/lib/postprocessing/image.js
@@ -20,6 +20,7 @@ const exec = util.promisify(require('child_process').exec);
 const { Storage } = require('@adobe/asset-compute-pipeline');
 const { Dimensions } = require("./math");
 const unitConvert = require('css-unit-converter');
+const fs = require('fs-extra');
 const gm = require("./gm-promisify");
 
 const SVG_DEFAULT_WIDTH = 400; // Same value in AEM for SVGs
@@ -27,12 +28,12 @@ const WATERMARK_NAME = 'watermark.png';
 // list of supported output formats
 // maps our fmt ('png') to imagemagick format ('PNG') https://imagemagick.org/script/formats.php
 const SUPPORTED_OUTPUT_FMT = {
-    "png" : "PNG",
-    "jpg" : "JPEG",
+    "png": "PNG",
+    "jpg": "JPEG",
     "jpeg": "JPEG",
-    "tif" : "TIFF",
+    "tif": "TIFF",
     "tiff": "TIFF",
-    "gif" : "GIF",
+    "gif": "GIF",
     "webp": "WEBP"
 };
 
@@ -41,14 +42,14 @@ const SUPPORTED_OUTPUT_FMT = {
 // Note: order is important and defines priority for intermediate format - first entry will be most preferred
 const SUPPORTED_INPUT_TYPES = {
     "TIFF": "tif",  // most preferred format as it allows to preserve many features
-    "PNG" : "png",  // lossless over
+    "PNG": "png",  // lossless over
     "JPEG": "jpg",  // ..lossy
-    "GIF" : "gif",  // (should never get here in practice)
-    "BMP" : "bmp",
-    "SVG" : "svg",
-    "SGI" : "sgi",
+    "GIF": "gif",  // (should never get here in practice)
+    "BMP": "bmp",
+    "SVG": "svg",
+    "SGI": "sgi",
     "RGBA": "rgba",
-    "RGB" : "rgb"
+    "RGB": "rgb"
 };
 const SUPPORTED_INPUT_FORMAT_IMAGEMAGICK = Object.keys(SUPPORTED_INPUT_TYPES);
 const SUPPORTED_INPUT_FMT = Object.values(SUPPORTED_INPUT_TYPES);
@@ -59,13 +60,13 @@ const DEFAULT_WORKER_SUPPORTED_OUTPUT_FMT = [
 
 // list of formats supporting transparency
 const FORMAT_SUPPORTS_TRANSPARENCY = {
-    "png" : true,
-    "tif" : true,
+    "png": true,
+    "tif": true,
     "tiff": true,
-    "gif" : true,
-    "bmp" : true,
+    "gif": true,
+    "bmp": true,
     "webp": true,
-    "svg" : true,
+    "svg": true,
     "rgba": true
 };
 const DEFAULT_BACKGROUND_COLOR = "rgb(255,255,255)";
@@ -122,7 +123,7 @@ async function readImageMetadataWithImageMagick(file) {
             imageMagickMetadata = json.image;
         }
 
-        if(imageMagickMetadata){
+        if (imageMagickMetadata) {
             metadata = {};
             metadata.FileType = imageMagickMetadata.format;
             metadata.Orientation = imageMagickMetadata.orientation;
@@ -136,13 +137,13 @@ async function readImageMetadataWithImageMagick(file) {
         console.log(`Reading metadata using imagemagick failed with error ${err}`);
 
         // remove anything that might have been added to the object
-        metadata = null; 
+        metadata = null;
     }
 
     return metadata;
 }
 
-function normalizeMetadata(metadata){
+function normalizeMetadata(metadata) {
     // unit conversions - SVG sizes may be in points (`pt`)
     if (typeof metadata.ImageHeight === "string") {
         metadata.ImageHeight = convertUnit(metadata.ImageHeight);
@@ -152,7 +153,7 @@ function normalizeMetadata(metadata){
         metadata.ImageWidth = convertUnit(metadata.ImageWidth);
     }
 
-    if(metadata.FileType && metadata.FileType === "XMP"){
+    if (metadata.FileType && metadata.FileType === "XMP") {
         /*
             exiftool gets an intermediate file which has some extension, as the worker 
             created an intermediate (test-worker does symlinks).
@@ -168,16 +169,16 @@ function normalizeMetadata(metadata){
     return metadata;
 }
 
-function convertUnit(stringValueWithUnit){
+function convertUnit(stringValueWithUnit) {
     let valueInPixels;
 
     // get value
-    const numberMatcher = /(\d*\.?\d+)\s?(px|cm|mm|in|pt|pc)/ ;
+    const numberMatcher = /(\d*\.?\d+)\s?(px|cm|mm|in|pt|pc)/;
     const result = stringValueWithUnit.match(numberMatcher);
     // get unit, if any (no unit means it's in pixels)
 
     // convert to pixels
-    if(result && Array.isArray(result)){
+    if (result && Array.isArray(result)) {
         valueInPixels = unitConvert(result[1], result[2], 'px');
         valueInPixels = Math.round(valueInPixels);
     }
@@ -234,7 +235,7 @@ function hasJpegQuality(metadata, instructions) {
 }
 
 function needsOrientationApplied(metadata) {
-    if (typeof(metadata.Orientation) === "number" && metadata.Orientation > 1 && metadata.Orientation < 9) {
+    if (typeof (metadata.Orientation) === "number" && metadata.Orientation > 1 && metadata.Orientation < 9) {
         return true;
     }
 }
@@ -298,7 +299,7 @@ async function getImageMetadata(file) {
             "-ImageWidth",
             "-JPEGQualityEstimate"
         ];
-        const attributesToExtract = attributes.join(" "); 
+        const attributesToExtract = attributes.join(" ");
         const command = `exiftool -n -json ${attributesToExtract} ${file}`;
 
         // To get all metadata (even computed): 
@@ -313,7 +314,7 @@ async function getImageMetadata(file) {
             metadata = metadata[0];
         }
 
-        if(metadata){
+        if (metadata) {
             // normalization: 
             // - convert units which are not in pixels to pixels
             // - deal with some formats being wrongly identified as XMP
@@ -327,13 +328,13 @@ async function getImageMetadata(file) {
             console.log("exiftool can't read metadata because it doesn't know the file format");
 
             metadata = await readImageMetadataWithImageMagick(file);
-            if(metadata !== null){
+            if (metadata !== null) {
                 return metadata;
             }
         }
 
         throw new GenericError(`Reading metadata from intermediate rendition failed: ${e.message}`);
-    } 
+    }
 }
 
 /**
@@ -364,7 +365,7 @@ async function needsImagePostProcess(rendition, source) {
     const metadata = await getImageMetadata(rendition.path);
     rendition._intermediateMetadata = metadata;
 
-    if(!metadata.FileType){
+    if (!metadata.FileType) {
         // could not recognize filetype - most likely it is corrupt
         throw new SourceCorruptError(`Rendition seems to be corrupt. Could not identify file type.`);
     }
@@ -563,7 +564,15 @@ async function applyOutputProperties(img, instructions) {
     }
 
     // Most asset compute renditions are used in digital display context (web, screens), where RGB is required
-    if(SRGB_COLOR_PROFILE_FILE){
+    let useColorProfileFile = false;
+    if (SRGB_COLOR_PROFILE_FILE) {
+        const colorProfileFileExists = await fs.pathExists(SRGB_COLOR_PROFILE_FILE);
+        if (colorProfileFileExists) {
+            useColorProfileFile = true;
+        }
+    }
+
+    if(useColorProfileFile){
         console.log(`Using sRGB profile file: ${SRGB_COLOR_PROFILE_FILE}`);
         img.profile(SRGB_COLOR_PROFILE_FILE);
     } else {
@@ -635,14 +644,14 @@ function convertSvg(img, instructions) {
 }
 
 // gm("img.png").set(attribute, value)
-function handleTransparency(img, fmt){
+function handleTransparency(img, fmt) {
     if (FORMAT_SUPPORTS_TRANSPARENCY[fmt]) {
         img.background(DEFAULT_TRANSPARENCCY_BACKGROUND); // Keep transparency
     } else {
         img.background(DEFAULT_BACKGROUND_COLOR); // Change tranparency background to default background color 
         img.flatten();  // forces the image on its background to "commit" the background
     }
-    
+
     return img;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1698,9 +1698,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
-      "integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
@@ -6665,18 +6665,18 @@
       "dev": true
     },
     "npm": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.4.0.tgz",
-      "integrity": "sha512-j32JsNpXI0TwuZd2p67X+U83lEqHrc0+CGIUGNwQqubMPj610+BongAfX0SmTCvyz7PzSIkxftuInNSmweF0hQ==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.5.3.tgz",
+      "integrity": "sha512-O+1j66Alx7ZQgWnUSSTaz8rTqQrJnqNb8Num5uQw2vYvc2RrxLaX7cWtRkDhvkPIL8Nf2WU9gx1oSu268QConA==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^4.3.0",
-        "@npmcli/ci-detect": "^1.4.0",
-        "@npmcli/config": "^2.4.0",
+        "@npmcli/arborist": "^5.0.0",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.0.1",
         "@npmcli/map-workspaces": "^2.0.0",
         "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^2.0.0",
+        "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
@@ -6685,47 +6685,47 @@
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
+        "cli-table3": "^0.6.1",
+        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
         "glob": "^7.2.0",
-        "graceful-fs": "^4.2.8",
+        "graceful-fs": "^4.2.9",
         "hosted-git-info": "^4.1.0",
         "ini": "^2.0.0",
-        "init-package-json": "^2.0.5",
+        "init-package-json": "^3.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^5.0.1",
-        "libnpmdiff": "^3.0.0",
-        "libnpmexec": "^3.0.3",
-        "libnpmfund": "^2.0.2",
-        "libnpmhook": "^7.0.1",
-        "libnpmorg": "^3.0.1",
-        "libnpmpack": "^3.0.1",
-        "libnpmpublish": "^5.0.1",
-        "libnpmsearch": "^4.0.1",
-        "libnpmteam": "^3.0.1",
-        "libnpmversion": "^2.0.2",
-        "make-fetch-happen": "^10.0.0",
+        "libnpmaccess": "^6.0.0",
+        "libnpmdiff": "^4.0.0",
+        "libnpmexec": "^4.0.0",
+        "libnpmfund": "^3.0.0",
+        "libnpmhook": "^8.0.0",
+        "libnpmorg": "^4.0.0",
+        "libnpmpack": "^4.0.0",
+        "libnpmpublish": "^6.0.0",
+        "libnpmsearch": "^5.0.0",
+        "libnpmteam": "^4.0.0",
+        "libnpmversion": "^3.0.0",
+        "make-fetch-happen": "^10.0.4",
         "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^8.4.1",
+        "node-gyp": "^9.0.0",
         "nopt": "^5.0.0",
         "npm-audit-report": "^2.1.5",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^6.0.0",
-        "npm-registry-fetch": "^12.0.1",
+        "npm-package-arg": "^9.0.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-profile": "^6.0.2",
+        "npm-registry-fetch": "^13.0.1",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.0",
+        "npmlog": "^6.0.1",
         "opener": "^1.5.2",
-        "pacote": "^12.0.3",
+        "pacote": "^13.0.3",
         "parse-conflict-json": "^2.0.1",
-        "proc-log": "^1.0.0",
+        "proc-log": "^2.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
         "read-package-json": "^4.1.1",
@@ -6740,11 +6740,11 @@
         "treeverse": "^1.0.4",
         "validate-npm-package-name": "~3.0.0",
         "which": "^2.0.2",
-        "write-file-atomic": "^4.0.0"
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
         "@gar/promisify": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -6754,19 +6754,19 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "4.3.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/map-workspaces": "^2.0.0",
-            "@npmcli/metavuln-calculator": "^2.0.0",
+            "@npmcli/metavuln-calculator": "^3.0.0",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "bin-links": "^3.0.0",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
@@ -6774,13 +6774,15 @@
             "json-stringify-nice": "^1.1.4",
             "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^5.0.0",
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.5",
-            "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^12.0.1",
-            "pacote": "^12.0.2",
+            "npm-package-arg": "^9.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.0",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.2",
             "parse-conflict-json": "^2.0.1",
-            "proc-log": "^1.0.0",
+            "proc-log": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
@@ -6793,19 +6795,22 @@
           }
         },
         "@npmcli/ci-detect": {
-          "version": "1.4.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.4.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/map-workspaces": "^2.0.1",
             "ini": "^2.0.0",
             "mkdirp-infer-owner": "^2.0.0",
             "nopt": "^5.0.0",
-            "semver": "^7.3.4",
+            "proc-log": "^2.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "semver": "^7.3.5",
             "walk-up-path": "^1.0.0"
           }
         },
@@ -6818,7 +6823,7 @@
           }
         },
         "@npmcli/fs": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6827,18 +6832,26 @@
           }
         },
         "@npmcli/git": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/promise-spawn": "^1.3.2",
-            "lru-cache": "^6.0.0",
+            "lru-cache": "^7.3.1",
             "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^6.1.1",
+            "npm-pick-manifest": "^7.0.0",
+            "proc-log": "^2.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.4.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "@npmcli/installed-package-contents": {
@@ -6851,25 +6864,43 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.1.6",
-            "minimatch": "^3.0.4",
-            "read-package-json-fast": "^2.0.1"
+            "glob": "^7.2.0",
+            "minimatch": "^5.0.0",
+            "read-package-json-fast": "^2.0.3"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^15.0.5",
+            "cacache": "^15.3.0",
             "json-parse-even-better-errors": "^2.3.1",
-            "pacote": "^12.0.0",
-            "semver": "^7.3.2"
+            "pacote": "^13.0.1",
+            "semver": "^7.3.5"
           }
         },
         "@npmcli/move-file": {
@@ -6908,14 +6939,14 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "2.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^1.0.2",
+            "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/promise-spawn": "^1.3.2",
-            "node-gyp": "^8.2.0",
-            "read-package-json-fast": "^2.0.1"
+            "node-gyp": "^9.0.0",
+            "read-package-json-fast": "^2.0.3"
           }
         },
         "@tootallnate/once": {
@@ -6937,7 +6968,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6954,11 +6985,6 @@
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
           }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -6989,7 +7015,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7105,21 +7131,6 @@
               "bundled": true,
               "dev": true
             },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
             "strip-ansi": {
               "version": "6.0.1",
               "bundled": true,
@@ -7131,43 +7142,12 @@
           }
         },
         "cli-table3": {
-          "version": "0.6.0",
+          "version": "0.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
+            "colors": "1.4.0",
             "string-width": "^4.2.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
           }
         },
         "clone": {
@@ -7208,12 +7188,27 @@
           "optional": true
         },
         "columnify": {
-          "version": "1.5.4",
+          "version": "1.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
+            "strip-ansi": "^6.0.1",
             "wcwidth": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         },
         "common-ancestor-path": {
@@ -7232,7 +7227,7 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.2",
+          "version": "4.3.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7331,40 +7326,25 @@
           "dev": true
         },
         "gauge": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.0",
+            "signal-exit": "^3.0.7",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.2"
+            "wide-align": "^1.1.5"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "5.0.1",
               "bundled": true,
               "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
             },
             "strip-ansi": {
               "version": "6.0.1",
@@ -7390,7 +7370,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
+          "version": "4.2.9",
           "bundled": true,
           "dev": true
         },
@@ -7504,13 +7484,13 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.5",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^8.1.5",
+            "npm-package-arg": "^9.0.0",
             "promzard": "^0.3.0",
-            "read": "~1.0.1",
+            "read": "^1.0.7",
             "read-package-json": "^4.1.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
@@ -7536,7 +7516,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.8.0",
+          "version": "2.8.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7544,17 +7524,12 @@
           }
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "is-lambda": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -7589,18 +7564,18 @@
           "dev": true
         },
         "libnpmaccess": {
-          "version": "5.0.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^12.0.1"
+            "npm-package-arg": "^9.0.0",
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmdiff": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7609,102 +7584,104 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^12.0.0",
+            "npm-package-arg": "^9.0.0",
+            "pacote": "^13.0.2",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "3.0.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^4.0.0",
-            "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^2.0.0",
+            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-package-arg": "^8.1.2",
-            "pacote": "^12.0.0",
-            "proc-log": "^1.0.0",
+            "npm-package-arg": "^9.0.0",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.2",
+            "proc-log": "^2.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
             "walk-up-path": "^1.0.0"
           }
         },
         "libnpmfund": {
-          "version": "2.0.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^4.0.0"
+            "@npmcli/arborist": "^5.0.0"
           }
         },
         "libnpmhook": {
-          "version": "7.0.1",
+          "version": "8.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^12.0.1"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmorg": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^12.0.1"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmpack": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/run-script": "^2.0.0",
-            "npm-package-arg": "^8.1.0",
-            "pacote": "^12.0.0"
+            "@npmcli/run-script": "^3.0.0",
+            "npm-package-arg": "^9.0.0",
+            "pacote": "^13.0.2"
           }
         },
         "libnpmpublish": {
-          "version": "5.0.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "normalize-package-data": "^3.0.2",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^12.0.1",
+            "npm-package-arg": "^9.0.0",
+            "npm-registry-fetch": "^13.0.0",
             "semver": "^7.1.3",
             "ssri": "^8.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^12.0.1"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmteam": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^12.0.1"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmversion": {
-          "version": "2.0.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^2.0.0",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "json-parse-even-better-errors": "^2.3.1",
+            "proc-log": "^2.0.0",
             "semver": "^7.3.5",
             "stringify-package": "^1.0.1"
           }
@@ -7718,30 +7695,37 @@
           }
         },
         "make-fetch-happen": {
-          "version": "10.0.0",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^15.3.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
+            "lru-cache": "^7.4.0",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
+            "minipass-fetch": "^2.0.1",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
+            "socks-proxy-agent": "^6.1.1",
+            "ssri": "^8.0.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.4.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7765,14 +7749,14 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.4.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
             "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
+            "minizlib": "^2.1.2"
           }
         },
         "minipass-flush": {
@@ -7848,60 +7832,20 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "8.4.1",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^9.1.0",
+            "make-fetch-happen": "^10.0.3",
             "nopt": "^5.0.0",
             "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
             "tar": "^6.1.2",
             "which": "^2.0.2"
-          },
-          "dependencies": {
-            "@tootallnate/once": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true
-            },
-            "http-proxy-agent": {
-              "version": "4.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-              }
-            },
-            "make-fetch-happen": {
-              "version": "9.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agentkeepalive": "^4.1.3",
-                "cacache": "^15.2.0",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^6.0.0",
-                "minipass": "^3.1.3",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^1.3.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.2",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^6.0.0",
-                "ssri": "^8.0.0"
-              }
-            }
           }
         },
         "nopt": {
@@ -7953,12 +7897,12 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.1.5",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^4.0.1",
-            "semver": "^7.3.4",
+            "hosted-git-info": "^4.1.0",
+            "semver": "^7.3.5",
             "validate-npm-package-name": "^3.0.0"
           }
         },
@@ -7974,35 +7918,37 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "6.1.1",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-install-checks": "^4.0.0",
             "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^8.1.2",
-            "semver": "^7.3.4"
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "6.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^12.0.0"
+            "npm-registry-fetch": "^13.0.0",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "12.0.1",
+          "version": "13.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^10.0.0",
-            "minipass": "^3.1.3",
-            "minipass-fetch": "^1.3.0",
+            "make-fetch-happen": "^10.0.3",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.1",
             "minipass-json-stream": "^1.0.1",
-            "minizlib": "^2.0.0",
-            "npm-package-arg": "^8.0.0"
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.0",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -8011,20 +7957,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "6.0.0",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "^2.0.0",
+            "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
             "gauge": "^4.0.0",
             "set-blocking": "^2.0.0"
           }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
         },
         "once": {
           "version": "1.4.0",
@@ -8048,29 +7989,31 @@
           }
         },
         "pacote": {
-          "version": "12.0.3",
+          "version": "13.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.1.0",
-            "@npmcli/installed-package-contents": "^1.0.6",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^2.0.0",
-            "cacache": "^15.0.5",
+            "@npmcli/run-script": "^3.0.0",
+            "cacache": "^15.3.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "minipass": "^3.1.3",
-            "mkdirp": "^1.0.3",
-            "npm-package-arg": "^8.0.1",
+            "minipass": "^3.1.6",
+            "mkdirp": "^1.0.4",
+            "npm-package-arg": "^9.0.0",
             "npm-packlist": "^3.0.0",
-            "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^12.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.0",
+            "proc-log": "^2.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^2.0.1",
+            "read-package-json": "^4.1.1",
+            "read-package-json-fast": "^2.0.3",
             "rimraf": "^3.0.2",
             "ssri": "^8.0.1",
-            "tar": "^6.1.0"
+            "tar": "^6.1.11"
           }
         },
         "parse-conflict-json": {
@@ -8089,7 +8032,7 @@
           "dev": true
         },
         "proc-log": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -8222,7 +8165,7 @@
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.6",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true
         },
@@ -8232,16 +8175,16 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8274,7 +8217,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.10",
+          "version": "3.0.11",
           "bundled": true,
           "dev": true
         },
@@ -8287,25 +8230,26 @@
           }
         },
         "string-width": {
-          "version": "2.1.1",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "3.0.0",
+              "version": "5.0.1",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
-              "version": "4.0.0",
+              "version": "6.0.1",
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^5.0.1"
               }
             }
           }
@@ -8322,14 +8266,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -8364,11 +8300,6 @@
         },
         "treeverse": {
           "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "typedarray-to-buffer": {
-          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -8432,11 +8363,11 @@
           }
         },
         "wide-align": {
-          "version": "1.1.3",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrappy": {
@@ -8445,14 +8376,12 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^4.0.0"
+            "signal-exit": "^3.0.7"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rewire": "^6.0.0",
     "rimraf": "^3.0.2",
     "semantic-release": "^19.0.2",
-    "sinon": "^13.0.0"
+    "sinon": "^13.0.1"
   },
   "keywords": [
     "scripts",


### PR DESCRIPTION
## Description

Use the sRGB color profile file instead of default sRGB colorspace in post-processing when a default sRGB color profile file has been set (through an environment variable). Fallback to use default sRGB colorspace otherwise.

Fixes # [ASSETS-6954](https://jira.corp.adobe.com/browse/ASSETS-6954)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
