### PR TITLE
ASSETS-8997 add support for serviceoverload rendition_failed reason

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ const {
     SourceFormatUnsupportedError,
     SourceUnsupportedError,
     SourceCorruptError,
-    RenditionTooLarge
+    RenditionTooLarge,
+    ServiceOverLoadError
 } = require('@adobe/asset-compute-commons');
 
 // -----------------------< exports >-----------------------------------
@@ -38,5 +39,6 @@ module.exports = {
     SourceFormatUnsupportedError,
     SourceUnsupportedError,
     SourceCorruptError,
-    RenditionTooLarge
+    RenditionTooLarge,
+    ServiceOverLoadError
 };

--- a/lib/shell/shellscript.js
+++ b/lib/shell/shellscript.js
@@ -141,6 +141,8 @@ function newScriptError(err, errorFile) {
                 return new errors.SourceFormatUnsupportedError(errJson.message || err.message || err);
             case errors.Reason.SourceUnsupported:
                 return new errors.SourceUnsupportedError(errJson.message || err.message || err);
+            case errors.Reason.ServiceOverLoad:
+                return new errors.ServiceOverLoadError(errJson.message || err.message || err);
             default:
                 return new errors.GenericError(errJson.message || err.message || err, `${Action.name}_shellScript`);
             }

--- a/test/shellscript.test.js
+++ b/test/shellscript.test.js
@@ -372,6 +372,20 @@ describe("api.js (shell)", () => {
             );
         });
 
+        it("should handle error.json - ServiceOverLoad instanceof ClientError", async () => {
+            createScript("worker.sh", `
+                echo '{ "reason": "ServiceOverLoad", "message": "too many requests" }' > $errorfile
+                exit 1
+            `);
+            const scriptWorker = new ShellScriptWorker(testUtil.simpleParams());
+
+            await assert.rejects(
+                scriptWorker.processWithScript(mockSource(), mockRendition()),
+                // check that instanceof works
+                err => err instanceof ClientError
+            );
+        });
+
         it("should handle error.json - malformed json", async () => {
             createScript("worker.sh", `
                 echo '{ "message": MALFORMED' > $errorfile


### PR DESCRIPTION
jira: https://jira.corp.adobe.com/browse/ASSETS-8997
depends on upstream [@adobe/asset-compute-commons PR#71](https://github.com/adobe/asset-compute-commons/pull/71)

Adds support for `ServiceOverLoad` rendition_failed reason in SDK in order to prevent coercion of `"reason": "ServiceOverLoad"` to GenericError prior to sending the event to Adobe I/O.