### PR TITLE
FEATURE-RELEASE: ASSETS-62041 PNG Compression

### DIFF
--- a/lib/postprocessing/image.js
+++ b/lib/postprocessing/image.js
@@ -92,7 +92,8 @@ const EXTRA_INSTRUCTIONS = new Set([
     "dpi",
     "convertToDpi",
     "watermark",
-    "pdfbgcolor"
+    "pdfbgcolor",
+    "compressionLevel"
 ]);
 
 const SRGB_COLOR_PROFILE_FILE = process.env.SRGB_COLOR_PROFILE_FILE;
@@ -499,9 +500,17 @@ async function applyOperations(img, intermediateRendition, rendition, directorie
 }
 
 async function applyOutputProperties(img, instructions) {
+    console.log(`applyOutputProperties: fmt=${instructions.fmt}, compressionLevel=${instructions.compressionLevel}, quality=${instructions.quality}`);
+
     // for reproducible png files
     if (instructions.fmt === "png") {
         img.define("png:exclude-chunks=date");
+
+        // png is lossless, so quality does not apply - use the zlib compression level (0-9) instead
+        // note: 0 is a valid value (no compression), so check explicitly for undefined/null
+        if (instructions.compressionLevel !== undefined && instructions.compressionLevel !== null) {
+            img.define(`png:compression-level=${instructions.compressionLevel}`);
+        }
     }
 
     if (instructions.fmt === "tif" || instructions.fmt === "tiff") {


### PR DESCRIPTION
## Description

Wires up the `compressionLevel` rendition instruction for PNG output. Previously
`compressionLevel` was accepted as a valid instruction (it triggered post-processing
and was logged) but was never applied to the output image — it had no effect.

PNG is a lossless format, so the JPEG-style `quality` value does not control visual
quality for PNG. This change maps `compressionLevel` to ImageMagick's
`png:compression-level` define (zlib level 0–9) in `applyOutputProperties()`,
giving callers explicit control over PNG compression.

Note: `compressionLevel: 0` (no compression) is treated as a valid value.

Fixes # (issue)
ASSETS-62041

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
